### PR TITLE
Hover-synced map highlighting for timeline segments

### DIFF
--- a/dist/card.js
+++ b/dist/card.js
@@ -1,4 +1,4 @@
-var css = ":host {\r\n  display: block;\r\n  font-family: var(--ha-card-header-font-family, \"Helvetica Neue\", Arial, sans-serif);\r\n}\r\n\r\nha-card {\r\n  overflow: hidden;\r\n}\r\n\r\n.card {\r\n  display: flex;\r\n  flex-direction: column;\r\n  height: 100%;\r\n}\r\n\r\n.header {\r\n  position: sticky;\r\n  top: 0;\r\n  z-index: 2;\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: space-between;\r\n  gap: 12px;\r\n  padding: 12px 16px;\r\n  background: var(--card-background-color, var(--ha-card-background, #fff));\r\n  border-bottom: 1px solid var(--divider-color);\r\n  flex-wrap: nowrap;\r\n}\r\n\r\n.date {\r\n  font-size: 1rem;\r\n  font-weight: 600;\r\n  text-align: center;\r\n  flex: 1;\r\n  white-space: nowrap;\r\n  overflow: hidden;\r\n  text-overflow: ellipsis;\r\n}\r\n\r\n.nav-button {\r\n  --mdc-icon-button-size: 36px;\r\n  color: var(--primary-text-color);\r\n}\r\n\r\n.header-actions {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  gap: 6px;\r\n}\r\n\r\n.nav-button[disabled] {\r\n  opacity: 0.4;\r\n  cursor: default;\r\n}\r\n\r\n.body {\r\n  padding: 8px 16px 16px;\r\n  max-height: 420px;\r\n  overflow: auto;\r\n}\r\n\r\n.loading,\r\n.error,\r\n.empty {\r\n  padding: 16px 0;\r\n  color: var(--secondary-text-color);\r\n  text-align: center;\r\n}\r\n\r\n.error {\r\n  color: var(--error-color, #c62828);\r\n}\r\n\r\n.timeline {\r\n  position: relative;\r\n  padding: 8px 0;\r\n}\r\n\r\n.spine {\r\n  position: absolute;\r\n  top: 0;\r\n  bottom: 0;\r\n  left: 72px;\r\n  width: 12px;\r\n  background: var(--primary-color);\r\n  border-radius: 999px;\r\n}\r\n\r\n.entry {\r\n  position: relative;\r\n  display: grid;\r\n  grid-template-columns: 50px 32px 1fr auto;\r\n  align-items: center;\r\n  column-gap: 12px;\r\n  padding: 12px 0;\r\n}\r\n\r\n.left-icon {\r\n  display: flex;\r\n  justify-content: flex-end;\r\n  padding-right: 4px;\r\n}\r\n\r\n.icon-ring {\r\n  width: 32px;\r\n  height: 32px;\r\n  border-radius: 50%;\r\n  background: var(--card-background-color, #fff);\r\n  border: 3px solid var(--primary-color);\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: center;\r\n  box-shadow: 0 0 0 4px var(--card-background-color, #fff);\r\n}\r\n\r\n.line-slot {\r\n  position: relative;\r\n  width: 32px;\r\n  height: 32px;\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: center;\r\n}\r\n\r\n.line-dot {\r\n  width: 10px;\r\n  height: 10px;\r\n  border-radius: 50%;\r\n  background: color-mix(in srgb, white 45%, transparent);\r\n}\r\n\r\n.stay-icon {\r\n  color: var(--primary-color);\r\n}\r\n\r\n.move-icon {\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.content {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 4px;\r\n}\r\n\r\n.content.location {\r\n  align-items: flex-start;\r\n}\r\n\r\n.content.location.travel {\r\n  flex-direction: row;\r\n  align-items: center;\r\n  gap: 6px;\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.content.time {\r\n  justify-self: end;\r\n  text-align: right;\r\n}\r\n\r\n.entry.move .title {\r\n  margin-left: 10px;\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.entry.stay .title{\r\n  background-color: #0001;\r\n  padding: 3px 10px;\r\n  border-radius: 20px;\r\n}\r\n\r\n.title {\r\n  font-size: 0.95rem;\r\n  font-weight: 600;\r\n  color: var(--primary-text-color);\r\n}\r\n\r\n.meta {\r\n  font-size: 0.85rem;\r\n  color: var(--secondary-text-color);\r\n  font-weight: normal;\r\n}\r\n\r\n.debug {\r\n  margin-top: 8px;\r\n  padding: 8px;\r\n  font-size: 0.75rem;\r\n  color: var(--secondary-text-color);\r\n  background: var(--secondary-background-color);\r\n  border-radius: 8px;\r\n}\r\n\r\n#overview-map {\r\n  height: 200px;\r\n}";
+var css = ":host {\n  display: block;\n  font-family: var(--ha-card-header-font-family, \"Helvetica Neue\", Arial, sans-serif);\n}\n\nha-card {\n  overflow: hidden;\n}\n\n.card {\n  display: flex;\n  flex-direction: column;\n  height: 100%;\n}\n\n.header {\n  position: sticky;\n  top: 0;\n  z-index: 2;\n  display: flex;\n  align-items: center;\n  justify-content: space-between;\n  gap: 12px;\n  padding: 12px 16px;\n  background: var(--card-background-color, var(--ha-card-background, #fff));\n  border-bottom: 1px solid var(--divider-color);\n  flex-wrap: nowrap;\n}\n\n.date {\n  font-size: 1rem;\n  font-weight: 600;\n  text-align: center;\n  flex: 1;\n  white-space: nowrap;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}\n\n.nav-button {\n  --mdc-icon-button-size: 36px;\n  color: var(--primary-text-color);\n}\n\n.header-actions {\n  display: inline-flex;\n  align-items: center;\n  gap: 6px;\n}\n\n.nav-button[disabled] {\n  opacity: 0.4;\n  cursor: default;\n}\n\n.body {\n  padding: 8px 16px 16px;\n  max-height: 420px;\n  overflow: auto;\n}\n\n.loading,\n.error,\n.empty {\n  padding: 16px 0;\n  color: var(--secondary-text-color);\n  text-align: center;\n}\n\n.error {\n  color: var(--error-color, #c62828);\n}\n\n.timeline {\n  position: relative;\n  padding: 8px 0;\n}\n\n.spine {\n  position: absolute;\n  top: 0;\n  bottom: 0;\n  left: 72px;\n  width: 12px;\n  background: var(--primary-color);\n  border-radius: 999px;\n}\n\n.entry {\n  position: relative;\n  display: grid;\n  grid-template-columns: 50px 32px 1fr auto;\n  align-items: center;\n  column-gap: 12px;\n  padding: 12px 0;\n}\n\n.left-icon {\n  display: flex;\n  justify-content: flex-end;\n  padding-right: 4px;\n}\n\n.icon-ring {\n  width: 32px;\n  height: 32px;\n  border-radius: 50%;\n  background: var(--card-background-color, #fff);\n  border: 3px solid var(--primary-color);\n  display: flex;\n  align-items: center;\n  justify-content: center;\n  box-shadow: 0 0 0 4px var(--card-background-color, #fff);\n}\n\n.line-slot {\n  position: relative;\n  width: 32px;\n  height: 32px;\n  display: flex;\n  align-items: center;\n  justify-content: center;\n}\n\n.line-dot {\n  width: 10px;\n  height: 10px;\n  border-radius: 50%;\n  background: color-mix(in srgb, white 45%, transparent);\n}\n\n.stay-icon {\n  color: var(--primary-color);\n}\n\n.move-icon {\n  color: var(--secondary-text-color);\n}\n\n.content {\n  display: flex;\n  flex-direction: column;\n  gap: 4px;\n}\n\n.content.location {\n  align-items: flex-start;\n}\n\n.content.location.travel {\n  flex-direction: row;\n  align-items: center;\n  gap: 6px;\n  color: var(--secondary-text-color);\n}\n\n.content.time {\n  justify-self: end;\n  text-align: right;\n}\n\n.entry.move .title {\n  margin-left: 10px;\n  color: var(--secondary-text-color);\n}\n\n.entry.stay .title{\n  background-color: #0001;\n  padding: 3px 10px;\n  border-radius: 20px;\n}\n\n.title {\n  font-size: 0.95rem;\n  font-weight: 600;\n  color: var(--primary-text-color);\n}\n\n.meta {\n  font-size: 0.85rem;\n  color: var(--secondary-text-color);\n  font-weight: normal;\n}\n\n.debug {\n  margin-top: 8px;\n  padding: 8px;\n  font-size: 0.75rem;\n  color: var(--secondary-text-color);\n  background: var(--secondary-background-color);\n  border-radius: 8px;\n}\n\n#overview-map {\n  height: 200px;\n}";
 
 function toDateKey(date) {
     const y = date.getFullYear();
@@ -307,15 +307,15 @@ function renderTimeline(segments) {
     return `
     <div class="timeline">
       <div class="spine"></div>
-      ${segments.map(renderSegment).join("")}
+      ${segments.map((segment, index) => renderSegment(segment, index)).join("")}
     </div>
   `;
 }
 
-function renderSegment(segment) {
+function renderSegment(segment, index) {
     if (segment.type === "stay") {
         return `
-      <div class="entry stay">
+      <div class="entry stay" data-segment-index="${index}" data-segment-type="stay">
         <div class="left-icon">
           <div class="icon-ring">
             <ha-icon class="stay-icon" icon="${segment.zoneIcon || "mdi:map-marker"}"></ha-icon>
@@ -335,7 +335,7 @@ function renderSegment(segment) {
     }
 
     return `
-    <div class="entry move">
+    <div class="entry move" data-segment-index="${index}" data-segment-type="move">
       <div class="left-icon"></div>
       <div class="line-slot"></div>
       <div class="content location travel">
@@ -502,6 +502,10 @@ class TimelineCard extends HTMLElement {
         this._loading = false;
         this._error = null;
         this._rendered = false;
+        this._fullDayPaths = [];
+        this._highlightedPath = [];
+        this._highlightedStay = [];
+        this._isTravelHighlightActive = false;
 
         this.shadowRoot.addEventListener("click", (event) => {
             const target = event.target.closest("[data-action]");
@@ -514,6 +518,20 @@ class TimelineCard extends HTMLElement {
             } else if (action === "refresh") {
                 this._refreshCurrentDay();
             }
+        });
+
+        this.shadowRoot.addEventListener("mouseover", (event) => {
+            const entry = event.target.closest("[data-segment-index]");
+            if (!entry || !this.shadowRoot.contains(entry)) return;
+            if (entry.contains(event.relatedTarget)) return;
+            this._handleSegmentHoverStart(Number(entry.dataset.segmentIndex));
+        });
+
+        this.shadowRoot.addEventListener("mouseout", (event) => {
+            const entry = event.target.closest("[data-segment-index]");
+            if (!entry || !this.shadowRoot.contains(entry)) return;
+            if (entry.contains(event.relatedTarget)) return;
+            this._clearHoverHighlight();
         });
     }
 
@@ -570,7 +588,7 @@ class TimelineCard extends HTMLElement {
         const existing = this._cache.get(key);
         if (existing && (existing.segments || existing.loading)) return;
 
-        this._cache.set(key, {loading: true, segments: null, error: null, debug: null});
+        this._cache.set(key, {loading: true, segments: null, points: null, error: null, debug: null});
         this._render();
 
         try {
@@ -593,12 +611,13 @@ class TimelineCard extends HTMLElement {
                 first: points[0]?.ts || null,
                 last: points[points.length - 1]?.ts || null,
             };
-            this._cache.set(key, {loading: false, segments, error: null, debug});
+            this._cache.set(key, {loading: false, segments, points, error: null, debug});
         } catch (err) {
             console.warn("Timeline card: history fetch failed", err);
             this._cache.set(key, {
                 loading: false,
                 segments: null,
+                points: null,
                 error: this._formatErrorMessage(err),
                 debug: null,
             });
@@ -623,7 +642,7 @@ class TimelineCard extends HTMLElement {
     _render() {
         if (!this.shadowRoot) return;
         const dateKey = toDateKey(this._selectedDate);
-        const dayData = this._cache.get(dateKey) || {loading: false, segments: null, error: null, debug: null};
+        const dayData = this._cache.get(dateKey) || {loading: false, segments: null, points: null, error: null, debug: null};
         const isFuture = this._selectedDate >= startOfDay(new Date());
 
         this.shadowRoot.innerHTML = `
@@ -650,6 +669,10 @@ class TimelineCard extends HTMLElement {
     `;
         if (this._config.show_map) {
             this._attachMapCard();
+        }
+
+        if (!dayData.loading) {
+            this._refreshMapPaths();
         }
     }
 
@@ -684,9 +707,129 @@ class TimelineCard extends HTMLElement {
 
     _fillMapCard() {
         const haMap = this._mapCard.shadowRoot?.querySelector("ha-map");
+        if (!haMap) return;
+
         haMap.style.height = "200px";
+        haMap.autoFit = false;
 
         this._mapCard._mapEntities = [];
+        this._refreshMapPaths();
+    }
+
+    _refreshMapPaths() {
+        if (!this._config.show_map || !this._mapCard) return;
+        const dayData = this._getCurrentDayData();
+        if (!dayData || dayData.loading || dayData.error) return;
+
+        const haMap = this._mapCard.shadowRoot?.querySelector("ha-map");
+        if (!haMap) return;
+
+        const points = Array.isArray(dayData.points) ? dayData.points : [];
+        this._fullDayPaths = points.length > 1
+            ? [{
+                points: points.map(toHaMapPoint).filter(Boolean),
+                color: "var(--primary-color)",
+                weight: 4,
+                gradualOpacity: 0.2,
+            }]
+            : [];
+
+        this._highlightedPath = [];
+        this._highlightedStay = [];
+        this._isTravelHighlightActive = false;
+
+        this._syncHaMapPaths();
+
+        if (this._fullDayPaths.length) {
+            haMap.fitBounds(this._fullDayPaths[0].points, {pad: 0.3});
+        }
+    }
+
+    _syncHaMapPaths() {
+        const haMap = this._mapCard?.shadowRoot?.querySelector("ha-map");
+        if (!haMap) return;
+
+        const basePaths = this._fullDayPaths.map((path) => ({
+            ...path,
+            gradualOpacity: this._isTravelHighlightActive ? 0.8 : path.gradualOpacity,
+        }));
+
+        haMap.paths = [
+            ...basePaths,
+            ...this._highlightedPath,
+            ...this._highlightedStay,
+        ];
+    }
+
+    _handleSegmentHoverStart(segmentIndex) {
+        if (!this._config.show_map || !Number.isInteger(segmentIndex)) return;
+        const dayData = this._getCurrentDayData();
+        if (!dayData || !Array.isArray(dayData.segments)) return;
+
+        const segment = dayData.segments[segmentIndex];
+        if (!segment) return;
+
+        const haMap = this._mapCard?.shadowRoot?.querySelector("ha-map");
+        if (!haMap) return;
+
+        this._highlightedPath = [];
+        this._highlightedStay = [];
+        this._isTravelHighlightActive = false;
+
+        if (segment.type === "stay") {
+            const centerPoint = segment.center ? toHaMapPoint(segment.center) : null;
+            if (!centerPoint) return;
+
+            this._highlightedStay = [{
+                points: [centerPoint],
+                color: "var(--accent-color)",
+                weight: 16,
+                gradualOpacity: 0,
+            }];
+            this._syncHaMapPaths();
+            haMap.fitBounds([centerPoint], {pad: 0.3});
+            return;
+        }
+
+        if (segment.type === "move") {
+            const segmentPoints = this._extractSegmentPoints(dayData.points, segment);
+            if (segmentPoints.length < 2) {
+                this._syncHaMapPaths();
+                return;
+            }
+
+            this._highlightedPath = [{
+                points: segmentPoints,
+                color: "var(--accent-color)",
+                weight: 6,
+                gradualOpacity: 0,
+            }];
+            this._isTravelHighlightActive = true;
+            this._syncHaMapPaths();
+            haMap.fitBounds(segmentPoints, {pad: 0.3});
+        }
+    }
+
+    _clearHoverHighlight() {
+        if (!this._highlightedPath.length && !this._highlightedStay.length && !this._isTravelHighlightActive) {
+            return;
+        }
+        this._highlightedPath = [];
+        this._highlightedStay = [];
+        this._isTravelHighlightActive = false;
+        this._syncHaMapPaths();
+    }
+
+    _extractSegmentPoints(points, segment) {
+        if (!Array.isArray(points)) return [];
+        return points
+            .filter((point) => point.ts >= segment.start && point.ts <= segment.end)
+            .map(toHaMapPoint)
+            .filter(Boolean);
+    }
+
+    _getCurrentDayData() {
+        return this._cache.get(toDateKey(this._selectedDate));
     }
 
     _renderDebug(dayData) {
@@ -708,6 +851,14 @@ class TimelineCard extends HTMLElement {
         }
         return message || "Unable to load history";
     }
+}
+
+function toHaMapPoint(point) {
+    if (!point) return null;
+    const latitude = Number(point.latitude ?? point.lat);
+    const longitude = Number(point.longitude ?? point.lon);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+    return {latitude, longitude};
 }
 
 function applyPlacesToStays(segments, placeStates, date) {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -8,15 +8,15 @@ export function renderTimeline(segments) {
     return `
     <div class="timeline">
       <div class="spine"></div>
-      ${segments.map(renderSegment).join("")}
+      ${segments.map((segment, index) => renderSegment(segment, index)).join("")}
     </div>
   `;
 }
 
-function renderSegment(segment) {
+function renderSegment(segment, index) {
     if (segment.type === "stay") {
         return `
-      <div class="entry stay">
+      <div class="entry stay" data-segment-index="${index}" data-segment-type="stay">
         <div class="left-icon">
           <div class="icon-ring">
             <ha-icon class="stay-icon" icon="${segment.zoneIcon || "mdi:map-marker"}"></ha-icon>
@@ -36,7 +36,7 @@ function renderSegment(segment) {
     }
 
     return `
-    <div class="entry move">
+    <div class="entry move" data-segment-index="${index}" data-segment-type="move">
       <div class="left-icon"></div>
       <div class="line-slot"></div>
       <div class="content location travel">


### PR DESCRIPTION
### Motivation
- Provide interactive spatial previews by synchronizing hover events on timeline entries with the embedded Lovelace `map` card using only its public APIs (no direct Leaflet access). 
- Ensure the full-day route remains the base layer while hover actions temporarily highlight stays or travel segments and programmatically control map fitting.

### Description
- Add per-segment metadata (`data-segment-index` / `data-segment-type`) to rendered timeline entries so hover events can map UI rows to segment data (`src/timeline.js`).
- Preserve raw per-day history `points` in the cache and construct explicit `ha-map` path objects for the full-day route stored in `_fullDayPaths`, with temporary overlays in `_highlightedPath` and `_highlightedStay` (`src/card.js`).
- Wire `mouseover` / `mouseout` listeners on the card shadow root to update highlight state without recreating the map card, and extract per-segment points to build overlay paths on hover (`_handleSegmentHoverStart`, `_clearHoverHighlight`, `_extractSegmentPoints`).
- Use the internal `<ha-map>` API only: set `haMap.autoFit = false`, assign `haMap.paths` to compose `[..._fullDayPaths, ..._highlightedPath, ..._highlightedStay]`, and call `haMap.fitBounds(...)` to zoom to the full-day route, stays, or travel segments as required (`src/card.js`).
- Visual behavior implemented: full-day path remains visible as base with low opacity, stay hover overlays a single-point focused marker, travel hover overlays a stronger path with `gradualOpacity: 0` and mutes the base path, and hover end clears overlays and restores base styling (`src/card.js`).

### Testing
- Ran the build step with `npm run build` which completed successfully and produced `dist/card.js`.
- No unit tests exist for runtime Lovelace/`ha-map` interaction in this environment, so correctness relies on runtime behavior in Home Assistant where the `map` card and `<ha-map>` are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699818f97de0832f808993f040d18f04)