### PR TITLE
Add localization support for timeline labels and configurable time display

### DIFF
--- a/dist/card.js
+++ b/dist/card.js
@@ -1,4 +1,55 @@
-var css = ":host {\r\n  display: block;\r\n  font-family: var(--ha-card-header-font-family, \"Helvetica Neue\", Arial, sans-serif);\r\n}\r\n\r\nha-card {\r\n  overflow: hidden;\r\n}\r\n\r\n.card {\r\n  display: flex;\r\n  flex-direction: column;\r\n  height: 100%;\r\n}\r\n\r\n.header {\r\n  position: sticky;\r\n  top: 0;\r\n  z-index: 2;\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: space-between;\r\n  gap: 12px;\r\n  padding: 12px 16px;\r\n  background: var(--card-background-color, var(--ha-card-background, #fff));\r\n  border-bottom: 1px solid var(--divider-color);\r\n  flex-wrap: nowrap;\r\n}\r\n\r\n.date-wrap {\r\n  display: flex;\r\n  justify-content: center;\r\n  flex: 1;\r\n  min-width: 0;\r\n}\r\n\r\n.date-trigger {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  border: 0;\r\n  background: transparent;\r\n  color: inherit;\r\n  font: inherit;\r\n  padding: 2px 4px;\r\n  margin: 0;\r\n  min-width: 0;\r\n  cursor: pointer;\r\n}\r\n\r\n.date {\r\n  font-size: 1rem;\r\n  font-weight: 600;\r\n  text-align: center;\r\n  white-space: nowrap;\r\n  overflow: hidden;\r\n  text-overflow: ellipsis;\r\n}\r\n\r\n.date-caret {\r\n  color: var(--secondary-text-color);\r\n  --mdc-icon-size: 20px;\r\n}\r\n\r\n.date-picker-input {\r\n  position: absolute;\r\n  opacity: 0;\r\n  pointer-events: none;\r\n  width: 0;\r\n  height: 0;\r\n}\r\n\r\n.nav-button {\r\n  --mdc-icon-button-size: 36px;\r\n  color: var(--primary-text-color);\r\n}\r\n\r\n.header-actions {\r\n  display: inline-flex;\r\n  align-items: center;\r\n  gap: 6px;\r\n}\r\n\r\n.nav-button[disabled] {\r\n  opacity: 0.4;\r\n  cursor: default;\r\n}\r\n\r\n.body {\r\n  padding: 8px 16px 16px;\r\n  max-height: 420px;\r\n  overflow: auto;\r\n  touch-action: pan-y;\r\n}\r\n\r\n.loading,\r\n.error,\r\n.empty {\r\n  padding: 16px 0;\r\n  color: var(--secondary-text-color);\r\n  text-align: center;\r\n}\r\n\r\n.error {\r\n  color: var(--error-color, #c62828);\r\n}\r\n\r\n.timeline {\r\n  position: relative;\r\n  padding: 8px 0;\r\n}\r\n\r\n.spine {\r\n  position: absolute;\r\n  top: 0;\r\n  bottom: 0;\r\n  left: 72px;\r\n  width: 12px;\r\n  background: var(--primary-color);\r\n  border-radius: 999px;\r\n}\r\n\r\n.timeline.trim-spine-top .spine {\r\n  top: 32px;\r\n}\r\n\r\n.timeline.trim-spine-bottom .spine {\r\n  bottom: 32px;\r\n}\r\n\r\n.entry {\r\n  position: relative;\r\n  display: grid;\r\n  grid-template-columns: 50px 32px 1fr auto;\r\n  align-items: center;\r\n  column-gap: 12px;\r\n  padding: 12px 0;\r\n}\r\n\r\n.left-icon {\r\n  display: flex;\r\n  justify-content: flex-end;\r\n  padding-right: 4px;\r\n}\r\n\r\n.icon-ring {\r\n  width: 32px;\r\n  height: 32px;\r\n  border-radius: 50%;\r\n  background: var(--card-background-color, #fff);\r\n  border: 3px solid var(--primary-color);\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: center;\r\n  box-shadow: 0 0 0 4px var(--card-background-color, #fff);\r\n}\r\n\r\n.line-slot {\r\n  position: relative;\r\n  width: 32px;\r\n  height: 32px;\r\n  display: flex;\r\n  align-items: center;\r\n  justify-content: center;\r\n}\r\n\r\n.line-dot {\r\n  width: 10px;\r\n  height: 10px;\r\n  border-radius: 50%;\r\n  background: color-mix(in srgb, white 45%, transparent);\r\n}\r\n\r\n.stay-icon {\r\n  color: var(--primary-color);\r\n}\r\n\r\n.move-icon {\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.content {\r\n  display: flex;\r\n  flex-direction: column;\r\n  gap: 4px;\r\n}\r\n\r\n.content.location {\r\n  align-items: flex-start;\r\n}\r\n\r\n.content.location.travel {\r\n  flex-direction: row;\r\n  align-items: center;\r\n  gap: 6px;\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.content.time {\r\n  justify-self: end;\r\n  text-align: right;\r\n}\r\n\r\n.entry.move .title {\r\n  margin-left: 10px;\r\n  color: var(--secondary-text-color);\r\n}\r\n\r\n.entry.stay .title{\r\n  background-color: #0001;\r\n  padding: 3px 10px;\r\n  border-radius: 20px;\r\n}\r\n\r\n.title {\r\n  font-size: 0.95rem;\r\n  font-weight: 600;\r\n  color: var(--primary-text-color);\r\n}\r\n\r\n.meta {\r\n  font-size: 0.85rem;\r\n  color: var(--secondary-text-color);\r\n  font-weight: normal;\r\n}\r\n\r\n.debug {\r\n  margin-top: 8px;\r\n  padding: 8px;\r\n  font-size: 0.75rem;\r\n  color: var(--secondary-text-color);\r\n  background: var(--secondary-background-color);\r\n  border-radius: 8px;\r\n}\r\n\r\n.map-wrap {\r\n  position: relative;\r\n}\r\n\r\n#overview-map {\r\n  height: 200px;\r\n}\r\n\r\n.map-reset {\r\n  position: absolute;\r\n  top: 8px;\r\n  right: 8px;\r\n  z-index: 3;\r\n  --mdc-icon-button-size: 34px;\r\n  background: var(--card-background-color, #fff);\r\n  border-radius: 50%;\r\n  box-shadow: 0 2px 6px #0003;\r\n}\r\n\r\n.map-reset[hidden] {\r\n  display: none;\r\n}\r\n";
+var css = ":host {\n  display: block;\n  font-family: var(--ha-card-header-font-family, \"Helvetica Neue\", Arial, sans-serif);\n}\n\nha-card {\n  overflow: hidden;\n}\n\n.card {\n  display: flex;\n  flex-direction: column;\n  height: 100%;\n}\n\n.header {\n  position: sticky;\n  top: 0;\n  z-index: 2;\n  display: flex;\n  align-items: center;\n  justify-content: space-between;\n  gap: 12px;\n  padding: 12px 16px;\n  background: var(--card-background-color, var(--ha-card-background, #fff));\n  border-bottom: 1px solid var(--divider-color);\n  flex-wrap: nowrap;\n}\n\n.date-wrap {\n  display: flex;\n  justify-content: center;\n  flex: 1;\n  min-width: 0;\n}\n\n.date-trigger {\n  display: inline-flex;\n  align-items: center;\n  border: 0;\n  background: transparent;\n  color: inherit;\n  font: inherit;\n  padding: 2px 4px;\n  margin: 0;\n  min-width: 0;\n  cursor: pointer;\n}\n\n.date {\n  font-size: 1rem;\n  font-weight: 600;\n  text-align: center;\n  white-space: nowrap;\n  overflow: hidden;\n  text-overflow: ellipsis;\n}\n\n.date-caret {\n  color: var(--secondary-text-color);\n  --mdc-icon-size: 20px;\n}\n\n.date-picker-input {\n  position: absolute;\n  opacity: 0;\n  pointer-events: none;\n  width: 0;\n  height: 0;\n}\n\n.nav-button {\n  --mdc-icon-button-size: 36px;\n  color: var(--primary-text-color);\n}\n\n.header-actions {\n  display: inline-flex;\n  align-items: center;\n  gap: 6px;\n}\n\n.nav-button[disabled] {\n  opacity: 0.4;\n  cursor: default;\n}\n\n.body {\n  padding: 8px 16px 16px;\n  max-height: 420px;\n  overflow: auto;\n  touch-action: pan-y;\n}\n\n.loading,\n.error,\n.empty {\n  padding: 16px 0;\n  color: var(--secondary-text-color);\n  text-align: center;\n}\n\n.error {\n  color: var(--error-color, #c62828);\n}\n\n.timeline {\n  position: relative;\n  padding: 8px 0;\n}\n\n.spine {\n  position: absolute;\n  top: 0;\n  bottom: 0;\n  left: 72px;\n  width: 12px;\n  background: var(--primary-color);\n  border-radius: 999px;\n}\n\n.timeline.trim-spine-top .spine {\n  top: 32px;\n}\n\n.timeline.trim-spine-bottom .spine {\n  bottom: 32px;\n}\n\n.entry {\n  position: relative;\n  display: grid;\n  grid-template-columns: 50px 32px 1fr auto;\n  align-items: center;\n  column-gap: 12px;\n  padding: 12px 0;\n}\n\n.left-icon {\n  display: flex;\n  justify-content: flex-end;\n  padding-right: 4px;\n}\n\n.icon-ring {\n  width: 32px;\n  height: 32px;\n  border-radius: 50%;\n  background: var(--card-background-color, #fff);\n  border: 3px solid var(--primary-color);\n  display: flex;\n  align-items: center;\n  justify-content: center;\n  box-shadow: 0 0 0 4px var(--card-background-color, #fff);\n}\n\n.line-slot {\n  position: relative;\n  width: 32px;\n  height: 32px;\n  display: flex;\n  align-items: center;\n  justify-content: center;\n}\n\n.line-dot {\n  width: 10px;\n  height: 10px;\n  border-radius: 50%;\n  background: color-mix(in srgb, white 45%, transparent);\n}\n\n.stay-icon {\n  color: var(--primary-color);\n}\n\n.move-icon {\n  color: var(--secondary-text-color);\n}\n\n.content {\n  display: flex;\n  flex-direction: column;\n  gap: 4px;\n}\n\n.content.location {\n  align-items: flex-start;\n}\n\n.content.location.travel {\n  flex-direction: row;\n  align-items: center;\n  gap: 6px;\n  color: var(--secondary-text-color);\n}\n\n.content.time {\n  justify-self: end;\n  text-align: right;\n}\n\n.entry.move .title {\n  margin-left: 10px;\n  color: var(--secondary-text-color);\n}\n\n.entry.stay .title{\n  background-color: #0001;\n  padding: 3px 10px;\n  border-radius: 20px;\n}\n\n.title {\n  font-size: 0.95rem;\n  font-weight: 600;\n  color: var(--primary-text-color);\n}\n\n.meta {\n  font-size: 0.85rem;\n  color: var(--secondary-text-color);\n  font-weight: normal;\n}\n\n.debug {\n  margin-top: 8px;\n  padding: 8px;\n  font-size: 0.75rem;\n  color: var(--secondary-text-color);\n  background: var(--secondary-background-color);\n  border-radius: 8px;\n}\n\n.map-wrap {\n  position: relative;\n}\n\n#overview-map {\n  height: 200px;\n}\n\n.map-reset {\n  position: absolute;\n  top: 8px;\n  right: 8px;\n  z-index: 3;\n  --mdc-icon-button-size: 34px;\n  background: var(--card-background-color, #fff);\n  border-radius: 50%;\n  box-shadow: 0 2px 6px #0003;\n}\n\n.map-reset[hidden] {\n  display: none;\n}\n";
+
+const TRANSLATIONS = {
+    en: {
+        allDay: "all day",
+        minuteShort: "min",
+        hourShort: "h",
+        moving: "Moving",
+        noHistory: "No location history for this day.",
+        loading: "Loading timeline...",
+    },
+    de: {
+        allDay: "ganztägig",
+        minuteShort: "Min",
+        hourShort: "Std",
+        moving: "Unterwegs",
+        noHistory: "Kein Standortverlauf für diesen Tag.",
+        loading: "Zeitachse wird geladen...",
+    },
+    nl: {
+        allDay: "hele dag",
+        minuteShort: "min",
+        hourShort: "u",
+        moving: "Onderweg",
+        noHistory: "Geen locatiegeschiedenis voor deze dag.",
+        loading: "Tijdlijn laden...",
+    },
+};
+
+function normalizeLanguageTag(language) {
+    if (typeof language !== "string") return "en";
+    return language.toLowerCase();
+}
+
+function createLocalizationContext(config = {}, hass = null) {
+    const requestedLanguage = normalizeLanguageTag(
+        config.locale || hass?.locale?.language || hass?.language || navigator.language || "en",
+    );
+
+    const [baseLanguage] = requestedLanguage.split("-");
+    const dictionary = TRANSLATIONS[requestedLanguage] || TRANSLATIONS[baseLanguage] || TRANSLATIONS.en;
+
+    return {
+        language: requestedLanguage,
+        dictionary,
+        timeDisplay: config.time_display || "auto",
+    };
+}
+
+function t(ctx, key) {
+    return ctx?.dictionary?.[key] || TRANSLATIONS.en[key] || key;
+}
 
 function toDateKey(date) {
     const y = date.getFullYear();
@@ -15,9 +66,9 @@ function endOfDay(date) {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
 }
 
-function formatDate(date) {
+function formatDate(date, localeContext) {
     try {
-        return new Intl.DateTimeFormat(undefined, {
+        return new Intl.DateTimeFormat(localeContext?.language, {
             weekday: "short",
             year: "numeric",
             month: "short",
@@ -28,40 +79,47 @@ function formatDate(date) {
     }
 }
 
-function formatTime(date) {
+function resolveHour12(timeDisplay) {
+    if (timeDisplay === "12h") return true;
+    if (timeDisplay === "24h") return false;
+    return undefined;
+}
+
+function formatTime(date, localeContext) {
     try {
-        return new Intl.DateTimeFormat(undefined, {
+        return new Intl.DateTimeFormat(localeContext?.language, {
             hour: "2-digit",
             minute: "2-digit",
+            hour12: resolveHour12(localeContext?.timeDisplay),
         }).format(date);
     } catch {
         return date.toLocaleTimeString();
     }
 }
 
-function formatTimeRange(start, end, options={}) {
+function formatTimeRange(start, end, options = {}, localeContext) {
     const hideStartTime = options.hideStartTime || false;
     const hideEndTime = options.hideEndTime || false;
 
     if (hideStartTime && hideEndTime) {
-        return "all day";
+        return t(localeContext, "allDay");
     } else if (hideStartTime && !hideEndTime) {
-        return formatTime(end);
+        return formatTime(end, localeContext);
     } else if (hideEndTime && !hideStartTime) {
-        return formatTime(start);
+        return formatTime(start, localeContext);
     } else {
-        return `${formatTime(start)} - ${formatTime(end)}`;
+        return `${formatTime(start, localeContext)} - ${formatTime(end, localeContext)}`;
     }
 }
 
-function formatDuration(ms) {
+function formatDuration(ms, localeContext) {
     const totalMinutes = ms > 0 ? Math.max(1, Math.round(ms / 60000)) : 0;
     const hours = Math.floor(totalMinutes / 60);
     const minutes = totalMinutes % 60;
     if (hours > 0) {
-        return `${hours} h ${minutes} min`;
+        return `${hours} ${t(localeContext, "hourShort")} ${minutes} ${t(localeContext, "minuteShort")}`;
     }
-    return `${minutes} min`;
+    return `${minutes} ${t(localeContext, "minuteShort")}`;
 }
 
 function formatDistance(meters) {
@@ -319,9 +377,9 @@ function resolveZone(center, zones) {
     return match;
 }
 
-function renderTimeline(segments) {
+function renderTimeline(segments, localeContext) {
     if (!segments || segments.length === 0) {
-        return `<div class="empty">No location history for this day.</div>`;
+        return `<div class="empty">${t(localeContext, "noHistory")}</div>`;
     }
 
     const firstIsStay = segments[0]?.type === "stay";
@@ -338,12 +396,12 @@ function renderTimeline(segments) {
       ${segments.map((segment, index) => renderSegment(segment, index, {
         hideStartTime: index === 0 && firstIsStay,
         hideEndTime: index === segments.length - 1 && lastIsStay,
-    })).join("")}
+    }, localeContext)).join("")}
     </div>
   `;
 }
 
-function renderSegment(segment, index, options) {
+function renderSegment(segment, index, options, localeContext) {
     if (segment.type === "stay") {
         return `
           <div class="entry stay" data-segment-index="${index}" data-segment-type="stay">
@@ -359,7 +417,7 @@ function renderSegment(segment, index, options) {
               <div class="title">${escapeHtml(segment.zoneName || segment.placeName || "Unknown location")}</div>
             </div>
             <div class="content time">
-              <div class="meta">${formatTimeRange(segment.start, segment.end, options)}</div>
+              <div class="meta">${formatTimeRange(segment.start, segment.end, options, localeContext)}</div>
             </div>
           </div>
         `;
@@ -371,10 +429,10 @@ function renderSegment(segment, index, options) {
       <div class="line-slot"></div>
       <div class="content location travel">
         <ha-icon class="move-icon" icon="mdi:chart-line-variant"></ha-icon>
-        <div class="title">Moving<span class="meta"> - ${formatDistance(segment.distanceM)}</span></div>
+        <div class="title">${t(localeContext, "moving")}<span class="meta"> - ${formatDistance(segment.distanceM)}</span></div>
       </div>
       <div class="content time">
-        <div class="meta">${formatDuration(segment.durationMs)}</div>
+        <div class="meta">${formatDuration(segment.durationMs, localeContext)}</div>
       </div>
     </div>
   `;
@@ -393,6 +451,8 @@ const OPTIONS = {
     stay_radius_m: 75,
     min_stay_minutes: 10,
     show_debug: false,
+    locale: null,
+    time_display: "auto",
 };
 
 class TimelineCardEditor extends HTMLElement {
@@ -455,6 +515,28 @@ class TimelineCardEditor extends HTMLElement {
         placesPicker.includeDomains = ["sensor"];
         placesPicker.addEventListener("value-changed", (ev) => this._onEntityFieldChanged("places_entity", ev));
 
+
+
+        const localeInput = document.createElement("ha-textfield");
+        localeInput.setAttribute("label", "Locale override (optional, e.g. en, de, nl)");
+        localeInput.value = this._config.locale || "";
+        localeInput.addEventListener("input", (ev) => this._onTextChanged("locale", ev));
+
+        const timeDisplay = document.createElement("ha-select");
+        timeDisplay.setAttribute("label", "Time display");
+        timeDisplay.value = this._config.time_display || OPTIONS.time_display;
+        [
+            { value: "auto", label: "Automatic (Home Assistant / browser)" },
+            { value: "24h", label: "24-hour" },
+            { value: "12h", label: "12-hour" },
+        ].forEach((optionDef) => {
+            const option = document.createElement("mwc-list-item");
+            option.value = optionDef.value;
+            option.textContent = optionDef.label;
+            timeDisplay.appendChild(option);
+        });
+        timeDisplay.addEventListener("change", (ev) => this._onSelectChanged("time_display", ev));
+
         const debugRow = document.createElement("label");
         debugRow.style.display = "flex";
         debugRow.style.alignItems = "center";
@@ -471,6 +553,8 @@ class TimelineCardEditor extends HTMLElement {
         form.appendChild(placesPicker);
         form.appendChild(stayRadius);
         form.appendChild(minStay);
+        form.appendChild(localeInput);
+        form.appendChild(timeDisplay);
         form.appendChild(debugRow);
         this.shadowRoot.appendChild(form);
     }
@@ -499,6 +583,18 @@ class TimelineCardEditor extends HTMLElement {
         this._emitChange();
     }
 
+    _onTextChanged(key, ev) {
+        const value = (ev?.target?.value || "").trim();
+        this._config = {...this._config, [key]: value || null};
+        this._emitChange();
+    }
+
+    _onSelectChanged(key, ev) {
+        const value = ev?.target?.value || ev?.detail?.value || OPTIONS[key];
+        this._config = {...this._config, [key]: value};
+        this._emitChange();
+    }
+
     _emitChange() {
         this.dispatchEvent(
             new CustomEvent("config-changed", {
@@ -518,6 +614,8 @@ const DEFAULT_CONFIG = {
     stay_radius_m: 75,
     min_stay_minutes: 10,
     show_debug: false,
+    locale: null,
+    time_display: "auto",
 };
 
 class TimelineCard extends HTMLElement {
@@ -712,6 +810,7 @@ class TimelineCard extends HTMLElement {
         if (!this.shadowRoot) return;
         this._ensureBaseLayout();
 
+        const localeContext = createLocalizationContext(this._config, this._hass);
         const dateKey = toDateKey(this._selectedDate);
         const dayData = this._cache.get(dateKey) || {
             loading: false, segments: null, points: null, error: null, debug: null
@@ -719,7 +818,7 @@ class TimelineCard extends HTMLElement {
         const isFuture = this._selectedDate >= startOfDay(new Date());
 
         const dateEl = this.shadowRoot.getElementById("timeline-date");
-        dateEl.textContent = formatDate(this._selectedDate);
+        dateEl.textContent = formatDate(this._selectedDate, localeContext);
 
         const datePicker = this.shadowRoot.getElementById("timeline-date-picker");
         if (datePicker) {
@@ -735,8 +834,8 @@ class TimelineCard extends HTMLElement {
         this._updateMapResetButton();
         body.innerHTML = `
               ${dayData.error ? `<div class="error">${dayData.error}</div>` : ""}
-              ${dayData.loading ? `<div class="loading">Loading timeline...</div>` : ""}
-              ${!dayData.loading && !dayData.error ? renderTimeline(dayData.segments) : ""}
+              ${dayData.loading ? `<div class="loading">${t(localeContext, "loading")}</div>` : ""}
+              ${!dayData.loading && !dayData.error ? renderTimeline(dayData.segments, localeContext) : ""}
               ${this._config.show_debug ? this._renderDebug(dayData) : ""}
             `;
         this._attachMapCard();

--- a/src/card.js
+++ b/src/card.js
@@ -3,6 +3,7 @@ import {fetchEntityHistory, fetchHistory} from "./history.js";
 import {segmentTimeline} from "./segmentation.js";
 import {renderTimeline} from "./timeline.js";
 import {formatDate, startOfDay, toDateKey, toLatLon} from "./utils.js";
+import {createLocalizationContext, t} from "./localization.js";
 import "./editor.js";
 
 const DEFAULT_CONFIG = {
@@ -11,6 +12,8 @@ const DEFAULT_CONFIG = {
     stay_radius_m: 75,
     min_stay_minutes: 10,
     show_debug: false,
+    locale: null,
+    time_display: "auto",
 };
 
 class TimelineCard extends HTMLElement {
@@ -205,6 +208,7 @@ class TimelineCard extends HTMLElement {
         if (!this.shadowRoot) return;
         this._ensureBaseLayout();
 
+        const localeContext = createLocalizationContext(this._config, this._hass);
         const dateKey = toDateKey(this._selectedDate);
         const dayData = this._cache.get(dateKey) || {
             loading: false, segments: null, points: null, error: null, debug: null
@@ -212,7 +216,7 @@ class TimelineCard extends HTMLElement {
         const isFuture = this._selectedDate >= startOfDay(new Date());
 
         const dateEl = this.shadowRoot.getElementById("timeline-date");
-        dateEl.textContent = formatDate(this._selectedDate);
+        dateEl.textContent = formatDate(this._selectedDate, localeContext);
 
         const datePicker = this.shadowRoot.getElementById("timeline-date-picker");
         if (datePicker) {
@@ -228,8 +232,8 @@ class TimelineCard extends HTMLElement {
         this._updateMapResetButton();
         body.innerHTML = `
               ${dayData.error ? `<div class="error">${dayData.error}</div>` : ""}
-              ${dayData.loading ? `<div class="loading">Loading timeline...</div>` : ""}
-              ${!dayData.loading && !dayData.error ? renderTimeline(dayData.segments) : ""}
+              ${dayData.loading ? `<div class="loading">${t(localeContext, "loading")}</div>` : ""}
+              ${!dayData.loading && !dayData.error ? renderTimeline(dayData.segments, localeContext) : ""}
               ${this._config.show_debug ? this._renderDebug(dayData) : ""}
             `;
         this._attachMapCard();

--- a/src/editor.js
+++ b/src/editor.js
@@ -3,6 +3,8 @@ const OPTIONS = {
     stay_radius_m: 75,
     min_stay_minutes: 10,
     show_debug: false,
+    locale: null,
+    time_display: "auto",
 };
 
 class TimelineCardEditor extends HTMLElement {
@@ -65,6 +67,28 @@ class TimelineCardEditor extends HTMLElement {
         placesPicker.includeDomains = ["sensor"];
         placesPicker.addEventListener("value-changed", (ev) => this._onEntityFieldChanged("places_entity", ev));
 
+
+
+        const localeInput = document.createElement("ha-textfield");
+        localeInput.setAttribute("label", "Locale override (optional, e.g. en, de, nl)");
+        localeInput.value = this._config.locale || "";
+        localeInput.addEventListener("input", (ev) => this._onTextChanged("locale", ev));
+
+        const timeDisplay = document.createElement("ha-select");
+        timeDisplay.setAttribute("label", "Time display");
+        timeDisplay.value = this._config.time_display || OPTIONS.time_display;
+        [
+            { value: "auto", label: "Automatic (Home Assistant / browser)" },
+            { value: "24h", label: "24-hour" },
+            { value: "12h", label: "12-hour" },
+        ].forEach((optionDef) => {
+            const option = document.createElement("mwc-list-item");
+            option.value = optionDef.value;
+            option.textContent = optionDef.label;
+            timeDisplay.appendChild(option);
+        });
+        timeDisplay.addEventListener("change", (ev) => this._onSelectChanged("time_display", ev));
+
         const debugRow = document.createElement("label");
         debugRow.style.display = "flex";
         debugRow.style.alignItems = "center";
@@ -81,6 +105,8 @@ class TimelineCardEditor extends HTMLElement {
         form.appendChild(placesPicker);
         form.appendChild(stayRadius);
         form.appendChild(minStay);
+        form.appendChild(localeInput);
+        form.appendChild(timeDisplay);
         form.appendChild(debugRow);
         this.shadowRoot.appendChild(form);
     }
@@ -106,6 +132,18 @@ class TimelineCardEditor extends HTMLElement {
 
     _onToggleChanged(key, ev) {
         this._config = {...this._config, [key]: Boolean(ev.target.checked)};
+        this._emitChange();
+    }
+
+    _onTextChanged(key, ev) {
+        const value = (ev?.target?.value || "").trim();
+        this._config = {...this._config, [key]: value || null};
+        this._emitChange();
+    }
+
+    _onSelectChanged(key, ev) {
+        const value = ev?.target?.value || ev?.detail?.value || OPTIONS[key];
+        this._config = {...this._config, [key]: value};
         this._emitChange();
     }
 

--- a/src/localization.js
+++ b/src/localization.js
@@ -1,0 +1,51 @@
+const TRANSLATIONS = {
+    en: {
+        allDay: "all day",
+        minuteShort: "min",
+        hourShort: "h",
+        moving: "Moving",
+        noHistory: "No location history for this day.",
+        loading: "Loading timeline...",
+    },
+    de: {
+        allDay: "ganztägig",
+        minuteShort: "Min",
+        hourShort: "Std",
+        moving: "Unterwegs",
+        noHistory: "Kein Standortverlauf für diesen Tag.",
+        loading: "Zeitachse wird geladen...",
+    },
+    nl: {
+        allDay: "hele dag",
+        minuteShort: "min",
+        hourShort: "u",
+        moving: "Onderweg",
+        noHistory: "Geen locatiegeschiedenis voor deze dag.",
+        loading: "Tijdlijn laden...",
+    },
+};
+
+function normalizeLanguageTag(language) {
+    if (!language || typeof language !== "string") return "en";
+    return language.toLowerCase();
+}
+
+export function createLocalizationContext(config = {}, hass = null) {
+    const requestedLanguage = normalizeLanguageTag(
+        config.locale || hass?.locale?.language || hass?.language || navigator.language || "en",
+    );
+
+    const [baseLanguage] = requestedLanguage.split("-");
+    const dictionary = TRANSLATIONS[requestedLanguage] || TRANSLATIONS[baseLanguage] || TRANSLATIONS.en;
+
+    return {
+        language: requestedLanguage,
+        dictionary,
+        timeDisplay: config.time_display || "auto",
+    };
+}
+
+export function t(ctx, key) {
+    return ctx?.dictionary?.[key] || TRANSLATIONS.en[key] || key;
+}
+

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -1,8 +1,9 @@
-import {formatDistance, formatDuration, formatTime, formatTimeRange} from "./utils.js";
+import {formatDistance, formatDuration, formatTimeRange} from "./utils.js";
+import {t} from "./localization.js";
 
-export function renderTimeline(segments) {
+export function renderTimeline(segments, localeContext) {
     if (!segments || segments.length === 0) {
-        return `<div class="empty">No location history for this day.</div>`;
+        return `<div class="empty">${t(localeContext, "noHistory")}</div>`;
     }
 
     const firstIsStay = segments[0]?.type === "stay";
@@ -19,12 +20,12 @@ export function renderTimeline(segments) {
       ${segments.map((segment, index) => renderSegment(segment, index, {
         hideStartTime: index === 0 && firstIsStay,
         hideEndTime: index === segments.length - 1 && lastIsStay,
-    })).join("")}
+    }, localeContext)).join("")}
     </div>
   `;
 }
 
-function renderSegment(segment, index, options) {
+function renderSegment(segment, index, options, localeContext) {
     if (segment.type === "stay") {
         return `
           <div class="entry stay" data-segment-index="${index}" data-segment-type="stay">
@@ -40,7 +41,7 @@ function renderSegment(segment, index, options) {
               <div class="title">${escapeHtml(segment.zoneName || segment.placeName || "Unknown location")}</div>
             </div>
             <div class="content time">
-              <div class="meta">${formatTimeRange(segment.start, segment.end, options)}</div>
+              <div class="meta">${formatTimeRange(segment.start, segment.end, options, localeContext)}</div>
             </div>
           </div>
         `;
@@ -52,10 +53,10 @@ function renderSegment(segment, index, options) {
       <div class="line-slot"></div>
       <div class="content location travel">
         <ha-icon class="move-icon" icon="mdi:chart-line-variant"></ha-icon>
-        <div class="title">Moving<span class="meta"> - ${formatDistance(segment.distanceM)}</span></div>
+        <div class="title">${t(localeContext, "moving")}<span class="meta"> - ${formatDistance(segment.distanceM)}</span></div>
       </div>
       <div class="content time">
-        <div class="meta">${formatDuration(segment.durationMs)}</div>
+        <div class="meta">${formatDuration(segment.durationMs, localeContext)}</div>
       </div>
     </div>
   `;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import {t} from "./localization.js";
+
 export function toDateKey(date) {
     const y = date.getFullYear();
     const m = String(date.getMonth() + 1).padStart(2, "0");
@@ -13,9 +15,9 @@ export function endOfDay(date) {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
 }
 
-export function formatDate(date) {
+export function formatDate(date, localeContext) {
     try {
-        return new Intl.DateTimeFormat(undefined, {
+        return new Intl.DateTimeFormat(localeContext?.language, {
             weekday: "short",
             year: "numeric",
             month: "short",
@@ -26,40 +28,47 @@ export function formatDate(date) {
     }
 }
 
-export function formatTime(date) {
+function resolveHour12(timeDisplay) {
+    if (timeDisplay === "12h") return true;
+    if (timeDisplay === "24h") return false;
+    return undefined;
+}
+
+export function formatTime(date, localeContext) {
     try {
-        return new Intl.DateTimeFormat(undefined, {
+        return new Intl.DateTimeFormat(localeContext?.language, {
             hour: "2-digit",
             minute: "2-digit",
+            hour12: resolveHour12(localeContext?.timeDisplay),
         }).format(date);
     } catch {
         return date.toLocaleTimeString();
     }
 }
 
-export function formatTimeRange(start, end, options={}) {
+export function formatTimeRange(start, end, options = {}, localeContext) {
     const hideStartTime = options.hideStartTime || false;
     const hideEndTime = options.hideEndTime || false;
 
     if (hideStartTime && hideEndTime) {
-        return "all day";
+        return t(localeContext, "allDay");
     } else if (hideStartTime && !hideEndTime) {
-        return formatTime(end);
+        return formatTime(end, localeContext);
     } else if (hideEndTime && !hideStartTime) {
-        return formatTime(start);
+        return formatTime(start, localeContext);
     } else {
-        return `${formatTime(start)} - ${formatTime(end)}`;
+        return `${formatTime(start, localeContext)} - ${formatTime(end, localeContext)}`;
     }
 }
 
-export function formatDuration(ms) {
+export function formatDuration(ms, localeContext) {
     const totalMinutes = ms > 0 ? Math.max(1, Math.round(ms / 60000)) : 0;
     const hours = Math.floor(totalMinutes / 60);
     const minutes = totalMinutes % 60;
     if (hours > 0) {
-        return `${hours} h ${minutes} min`;
+        return `${hours} ${t(localeContext, "hourShort")} ${minutes} ${t(localeContext, "minuteShort")}`;
     }
-    return `${minutes} min`;
+    return `${minutes} ${t(localeContext, "minuteShort")}`;
 }
 
 export function formatDistance(meters) {


### PR DESCRIPTION
### Motivation
- Provide localized string constants for timeline UI (e.g. `all day`, `Moving`, duration units) so the card reads correctly in other languages.
- Allow configuring `locale` and `time_display` (auto/24h/12h) so date/time rendering can follow Home Assistant/browser or an explicit override.
- Keep localization concerns centralized in a separate module to follow the existing project structure and make future translations easier.

### Description
- Added a new localization module `src/localization.js` exposing `createLocalizationContext(config,hass)` and `t(ctx,key)` and shipping basic `en`, `de`, and `nl` translations for keys like `allDay`, `minuteShort`, `hourShort`, `moving`, `noHistory`, and `loading`.
- Made date/time and duration formatters locale-aware in `src/utils.js` by accepting a `localeContext`, using `Intl.DateTimeFormat(locale, ...)`, supporting an explicit `time_display` preference (`auto`/`24h`/`12h`), and translating duration unit labels with `t`.
- Wired localization into rendering paths: `src/timeline.js` and `src/card.js` now pass a `localeContext` into timeline rendering and use `t` for empty/loading/moving strings and localized time ranges/durations.
- Added new config options `locale` and `time_display` (default `null` / `auto`) to `DEFAULT_CONFIG` and exposed corresponding editor controls in `src/editor.js` (a `ha-textfield` for `locale` and a `ha-select` for `time_display`) with change handlers.
- Built artifacts updated (`dist/card.js`) so the distribution contains the localized code paths.

### Testing
- Automated build: ran `npm run build` (Rollup) and it completed successfully with `dist/card.js` produced.
- No unit tests were present in the repository; changes were validated via the build only and no runtime HA UI rendering was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699971743458832fbcd0ced8132483bf)