### PR TITLE
Use active entity color for timeline spine/icons and limit map fit to active track

### DIFF
--- a/src/card.css
+++ b/src/card.css
@@ -167,7 +167,7 @@ ha-card {
   bottom: 0;
   left: 72px;
   width: 12px;
-  background: var(--primary-color);
+  background: var(--timeline-track-color, var(--primary-color));
   border-radius: 999px;
 }
 
@@ -199,7 +199,7 @@ ha-card {
   height: 32px;
   border-radius: 50%;
   background: var(--card-background-color, #fff);
-  border: 3px solid var(--primary-color);
+  border: 3px solid var(--timeline-track-color, var(--primary-color));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -223,11 +223,11 @@ ha-card {
 }
 
 .stay-icon {
-  color: var(--primary-color);
+  color: var(--timeline-track-color, var(--primary-color));
 }
 
 .move-icon {
-  color: var(--secondary-text-color);
+  color: var(--timeline-track-color, var(--primary-color));
 }
 
 .content {

--- a/src/card.js
+++ b/src/card.js
@@ -567,6 +567,7 @@ class TimelineCard extends HTMLElement {
             return renderTimeline(dayData.segments, {
                 locale: this._hass?.locale,
                 distanceUnit: this._config.distance_unit,
+                trackColor: getTrackColor(this._activeEntityIndex),
             });
         } catch (err) {
             const message = this._formatErrorMessage(err);

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -132,7 +132,7 @@ export class TimelineLeafletMap {
 
     fitMap({defer = false, bounds = null, pad = 0.1} = {}) {
         if (bounds === null) {
-            bounds = this._fullDayPaths.flatMap((path) => path.points.map((point) => point.point));
+            bounds = this._fullDayPath?.points?.map((point) => point.point) || [];
             if (!bounds.length) return;
         }
 

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -14,7 +14,7 @@ export function renderTimeline(segments, options = {}) {
     ].join(" ");
 
     return `
-    <div class="${timelineClass}">
+    <div class="${timelineClass}" style="--timeline-track-color: ${options.trackColor || "var(--primary-color)"};">
       <div class="spine"></div>
       ${segments.map((segment, index) => renderSegment(segment, index, {
         locale: options.locale,


### PR DESCRIPTION
### Motivation
- Make the timeline spine and icons reflect the currently selected person’s color instead of always using `--primary-color` so the UI matches the selected entity color. 
- Ensure map auto-fit focuses on the currently selected entity only so zoom/reset behavior does not include other entities’ tracks.

### Description
- Introduce a CSS variable `--timeline-track-color` and update the spine, icon ring border, stay icon and move icon to use `var(--timeline-track-color, var(--primary-color))` in `src/card.css`.
- Pass the active entity color into timeline rendering by adding a `trackColor` option to `renderTimeline` and setting it on the timeline container inline style in `src/timeline.js`.
- Provide the active entity color from the card by calling `getTrackColor(this._activeEntityIndex)` when invoking `renderTimeline` in `src/card.js`.
- Change `fitMap()` behavior in `src/leaflet-map.js` to default to the active entity path (`this._fullDayPath`) bounds instead of using all tracks (`_fullDayPaths`).

### Testing
- Ran `npm run build` to produce the bundle which completed successfully (build succeeded with non-blocking warnings). 
- Rendered a local HTML preview and captured a screenshot using Playwright to visually verify the timeline track color mapping, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9eb549d4832f89a5f24bf3cb6912)