### PR TITLE
fix: wrong variable type for `places_entity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ When multiple entities are configured, the card renders all tracks on the map an
 ## Configuration options
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `entity` | string or string[] | **required** | One or more `device_tracker`/`person` entities to pull GPS history from. | 
+| `entity` | string[] | **required** | One or more `device_tracker`/`person` entities to pull GPS history from. | 
 | **Reverse geocoding** |  |  | see [Reverse Geocoding](#reverse-geocoding) below|
-| `places_entity` | string or string[] | `null` | Optional `sensor` entity (or list) from Places integration used first for reverse geocoding. Lists must match `entity` order/count when provided. |
+| `places_entity` | string[] | `[]` | Optional `sensor` entity (or list) from Places integration used first for reverse geocoding. Lists must match `entity` order/count when provided. |
 | `osm_api_key` | string | `null` | Optional OSM Nominatim email address (used as API key) for reverse geocoding fallback. |
 | **Detection parameters** |  |  |  |
 | `stay_radius_m` | number | `75` | Radius (meters) used to detect a stay. |
@@ -56,7 +56,7 @@ When multiple entities are configured, the card renders all tracks on the map an
 | `distance_unit` | string | `"metric"` | Distance unit for moving segments: `metric` (`m`, `km`) or `imperial` (`ft`, `mi`). |
 | `map_appearance` | string | `"auto"` | Map appearance: `auto` (align with HA theme), `light`, or `dark`. |
 | `map_height_px` | number | `200` | Height of the map area in pixels. |
-| `colors` | string[] | `null` | Optional list of per-entity track colors. When set, these colors are used in order (cycled if needed) instead of HA `--primary-color`/`--color-x` variables. |
+| `colors` | string[] | `[]` | Optional list of per-entity track colors. When set, these colors are used in order (cycled if needed) instead of HA `--primary-color`/`--color-x` variables. |
 
 ## Reverse Geocoding
 For stays that are not clearly inside a Home Assistant zone, the card can resolve a human-friendly location name. This process is called **reverse geocoding**: converting latitude/longitude coordinates into an address or place label.

--- a/src/card.js
+++ b/src/card.js
@@ -9,14 +9,14 @@ import {renderTimeline} from "./timeline.js";
 import {getConfigFormSchema} from "./config-flow.js";
 
 const DEFAULT_CONFIG = {
-    entity: null,
-    places_entity: null,
+    entity: [],
+    places_entity: [],
     osm_api_key: null,
     stay_radius_m: 75,
     min_stay_minutes: 10,
     map_appearance: "auto",
     map_height_px: 200,
-    colors: null,
+    colors: [],
     debug: false,
 };
 
@@ -136,14 +136,14 @@ class TimelineCard extends HTMLElement {
     static getStubConfig() {
         return {
             entity: ["device_tracker.your_device"],
-            places_entity: null,
+            places_entity: [],
             osm_api_key: null,
             stay_radius_m: 75,
             min_stay_minutes: 10,
             distance_unit: "metric",
             map_appearance: "auto",
             map_height_px: 200,
-            colors: null,
+            colors: [],
         };
     }
 


### PR DESCRIPTION
When switching to allow multiple users, `places_entity` was still treated as a single item in the config form