### PR TITLE
Optimize config flow

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -133,20 +133,6 @@ class TimelineCard extends HTMLElement {
         return getConfigFormSchema();
     }
 
-    static getStubConfig() {
-        return {
-            entity: ["device_tracker.your_device"],
-            places_entity: [],
-            osm_api_key: null,
-            stay_radius_m: 75,
-            min_stay_minutes: 10,
-            distance_unit: "metric",
-            map_appearance: "auto",
-            map_height_px: 200,
-            colors: [],
-        };
-    }
-
     _syncMapAppearance() {
         let darkMode = Boolean(this._hass?.themes?.darkMode);
         if (this._config.map_appearance === "dark") {

--- a/src/config-flow.js
+++ b/src/config-flow.js
@@ -1,10 +1,10 @@
 export function getConfigFormSchema() {
     return {
         schema: [
-            {name: "entity", required: true, selector: {entity: {multiple: true}}},
+            {name: "entity", required: true, selector: {entity: {multiple: true, filter: [{domain: ["person", "device_tracker"]}]}}},
             {
                 type: "expandable", name: "", title: "Reverse geocoding", flatten: true, schema: [
-                    {name: "places_entity", selector: {entity: {multiple: true, filter: [{domain: "sensor"}]}}},
+                    {name: "places_entity", selector: {entity: {multiple: true, filter: [{domain: "sensor", integration: "places"}]}}},
                     {name: "osm_api_key", selector: {text: {type: "email"}}},
                 ]
             },


### PR DESCRIPTION
The default (stub) config was removed, since it added a lot of unneccessary config items to the default configuration when added from the GUI. Also filtered the domains / integrations for the entities, so now the GUI only shows `person.*` and `device_tracker.*` entities for `entity`, and only entities with integration `places` as `places_entity`.