### PR TITLE
Feature: add marker clusters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "dependencies": {
         "custom-card-helpers": "^1.9.0",
-        "leaflet": "^1.9.4"
+        "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.2",
@@ -737,6 +738,15 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
     },
     "node_modules/lit": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "custom-card-helpers": "^1.9.0",
-    "leaflet": "^1.9.4"
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3"
   }
 }

--- a/src/card.js
+++ b/src/card.js
@@ -1,5 +1,7 @@
 import css from "./card.css";
 import leafletCss from "leaflet/dist/leaflet.css";
+import leafletMarkerClusterCss from "leaflet.markercluster/dist/MarkerCluster.css"
+import leafletMarkerClusterDefaultCss from "leaflet.markercluster/dist/MarkerCluster.Default.css"
 import {getSegmentedTracks} from "./segmentation.js";
 import {
     escapeHtml,
@@ -192,7 +194,7 @@ class TimelineCard extends HTMLElement {
         this._baseLayoutReady = true;
 
         this.shadowRoot.innerHTML = `
-          <style>${css}\n${leafletCss}</style>
+          <style>${css}\n${leafletCss}\n${leafletMarkerClusterCss}\n${leafletMarkerClusterDefaultCss}</style>
           <ha-card>
             <div class="card">
               <div id="overview-map"></div>

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -1,4 +1,5 @@
 import Leaflet from "leaflet";
+import * as MarkerCluster from "leaflet.markercluster";
 import {getTrackColor} from "./utils.js";
 
 const DEFAULT_CENTER = [52.3731339, 4.8903147];
@@ -20,6 +21,7 @@ export class TimelineLeafletMap {
         });
         tileLayer.addTo(this._leafletMap);
         this._leafletMap.setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+        this._leafletMap.createPane("markerClusters");
 
         this._mapLayers = [];
         this._fullDayPaths = [];
@@ -178,7 +180,7 @@ export class TimelineLeafletMap {
     }
 
     _drawCurrentLocationMarkers() {
-        let markerGroup = Leaflet.layerGroup();
+        let markerGroup = new MarkerCluster.MarkerClusterGroup({clusterPane: "markerClusters"});
         if (this._currentLocations.length === 1){
             markerGroup.addLayer(this._Leaflet.marker(this._currentLocations[0].point, {icon: createDefaultCurrentLocationIcon(), zIndexOffset: 1000}));
         } else {


### PR DESCRIPTION
TODO: overwrites `window.L`, so marker clusters on a `type: map` on the same page no longer works