### PR TITLE
fix: language detection when `localStorage.language` is `"null"`

### DIFF
--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -5,7 +5,7 @@ const languages = {en, nl};
 
 export function localize(string, search = "", replace = "") {
     let lang = localStorage.getItem("selectedLanguage")
-    if (!lang) {
+    if (!lang || lang === "null") {
         const _hass = document.querySelector("home-assistant").hass
         lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
     }


### PR DESCRIPTION
Fix from https://github.com/konewka17/timeline_card/pull/61 didn't completely fix the issue. This should