### PR TITLE
Fix map tiles blocked by OSM referer policy

### DIFF
--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -21,6 +21,7 @@ export class TimelineLeafletMap {
             subdomains: "abcd",
             minZoom: 0,
             maxZoom: 20,
+            referrerPolicy: "no-referrer-when-downgrade",
         });
         tileLayer.addTo(this._leafletMap);
 


### PR DESCRIPTION
Set referrerPolicy on the Leaflet tile layer so the browser includes the page URL as the Referer header when fetching tiles. CARTO's CDN can route some requests through OSM tile servers, which require a Referer and otherwise return a 403 "Access blocked" error tile.

Fixes #83