### PR TITLE
Add Places v3 compatibility while keeping v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ osm_api_key: me@example.com
 
 If `osm_api_key` is not set, unresolved stays remain **Unknown location**.
 
+### Places v3 compatibility
+
+Places v3 is a breaking change in the Places integration itself: attributes such as `place_name` move from the main sensor to separate child sensors (e.g. `sensor.places_alice_place_name`). The card supports both Places v2 and v3 — no configuration changes are needed:
+
+- Keep pointing `places_entity` at the **main** Places sensor. On v3, the card automatically detects and reads the `..._place_name` child sensor (enabled by default in Places v3). Pointing `places_entity` directly at the `..._place_name` sensor also works.
+- With a top-level `places_entity` list, v2 sensors are matched to trackers via their `devicetracker_entityid` attribute. That attribute no longer exists in v3, so the card falls back to matching by list position — make sure the list has the same length and order as `entity` (as was already documented).
+- History from before the v3 upgrade keeps working: for those periods the card still reads the old attributes.
+
 ## Notes
 
 - The card reads raw GPS history from the tracked entity’s latitude/longitude attributes.

--- a/advanced.md
+++ b/advanced.md
@@ -54,7 +54,10 @@ entity:
 ### How `places_entity` resolution works
 
 1. **Per-entity override** — If a `places_entity` is specified in the entity object, it is used directly for that entity.
-2. **Top-level fallback** — If not specified per-entity, the card checks the top-level `places_entity` list and auto-matches by the `devicetracker_entityid` attribute on the Places sensor.
+2. **Top-level fallback** — If not specified per-entity, the card checks the top-level `places_entity` list and auto-matches by the `devicetracker_entityid` attribute on the Places sensor (Places v2).
+3. **Positional fallback** — Places v3 removed the `devicetracker_entityid` attribute. Sensors that cannot be matched by attribute are matched by list position, so the top-level `places_entity` list must have the same length and order as `entity`.
+
+On Places v3, the card additionally detects the `..._place_name` child sensor belonging to the configured Places sensor (via the entity registry) and uses its history for place names.
 
 This means you can mix both approaches:
 

--- a/src/reverse-geocoding.js
+++ b/src/reverse-geocoding.js
@@ -34,8 +34,11 @@ export function clearReverseGeocodingQueue() {
     }
 }
 
-export function resolveStaySegments(segments, placeStates, date, osmApiKey, onUpdate) {
-    const placeIntervals = buildPlaceIntervals(placeStates, date);
+export function resolveStaySegments(segments, placeStates, placeNameStates, date, osmApiKey, onUpdate) {
+    // Intervals from the Places v3 place_name child sensor take precedence: the main
+    // sensor's state only holds the (less clean) display-options string in v3.
+    const placeNameIntervals = buildIntervals(placeNameStates, date, placeNameSensorDisplayName);
+    const placeIntervals = buildIntervals(placeStates, date, placeDisplayName);
     for (const segment of segments) {
         if (segment.type !== "stay" || segment.zoneName) continue;
         if (segment.placeName && segment.placeName !== LOADING_LOCATION) continue;
@@ -54,10 +57,11 @@ export function resolveStaySegments(segments, placeStates, date, osmApiKey, onUp
         }
 
         // Load from `places`
-        const placeName = pickPlaceName(placeIntervals, segment.start, segment.end);
+        const placeName = pickPlaceName(placeNameIntervals, segment.start, segment.end)
+            || pickPlaceName(placeIntervals, segment.start, segment.end);
         if (placeName) {
             segment.placeName = placeName;
-            segment.reverseGeocoding = {source: "places", name: placeName, intervals: placeIntervals};
+            segment.reverseGeocoding = {source: "places", name: placeName, intervals: [...placeNameIntervals, ...placeIntervals]};
             setPersistentCache(segmentKey, segment.placeName, segment.reverseGeocoding);
             continue;
         }
@@ -149,12 +153,13 @@ async function resolveQueuedRequest(request, sessionAtStart) {
     onUpdate();
 }
 
-function buildPlaceIntervals(placeStates, date) {
+function buildIntervals(states, date, displayNameFn) {
+    if (!Array.isArray(states) || states.length === 0) return [];
     const endOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
-    return placeStates.map((state, index) => {
-        const next = placeStates[index + 1];
+    return states.map((state, index) => {
+        const next = states[index + 1];
         const end = next ? new Date(next.lu * 1000) : endOfDay;
-        const name = placeDisplayName(state);
+        const name = displayNameFn(state);
         return {
             start: new Date(state.lu * 1000),
             end,
@@ -167,6 +172,12 @@ function placeDisplayName(state) {
     const attrs = state.a || {};
     const formatted_address = attrs.street ? `${attrs.street} ${attrs.street_number || ""}, ${attrs.city}` : null;
     return attrs.place_name || formatted_address || state.s || attrs.formatted_address || null;
+}
+
+function placeNameSensorDisplayName(state) {
+    const value = typeof state.s === "string" ? state.s.trim() : "";
+    if (!value || value === "unknown" || value === "unavailable") return null;
+    return value;
 }
 
 function pickPlaceName(intervals, start, end) {

--- a/src/segmentation.js
+++ b/src/segmentation.js
@@ -1,4 +1,4 @@
-import {endOfDay, haversineMeters, startOfDay, toLatLon, toPoint} from "./utils.js";
+import {endOfDay, haversineMeters, resolvePlaceNameEntity, startOfDay, toLatLon, toPoint} from "./utils.js";
 import {resolveStaySegments} from "./reverse-geocoding.js";
 import {resolveActivities} from "./activity.js";
 
@@ -276,13 +276,17 @@ export async function getSegmentedTracks(date, config, hass, onQueueUpdate) {
             const points = filterSpeedOutliers(rawPoints, config.max_reasonable_speed_kmh);
 
             const placeEntityId = entry.places_entity || null;
-            const placeStates = placeEntityId ? await fetchEntityHistory(hass, placeEntityId, date) : [];
-
+            // Places v3 moved place_name from a state attribute to a separate child sensor
+            const placeNameEntityId = resolvePlaceNameEntity(hass, placeEntityId);
             const activityEntityId = entry.activity_entity || null;
-            const activityStates = activityEntityId ? await fetchEntityHistory(hass, activityEntityId, date) : [];
+            const [placeStates, placeNameStates, activityStates] = await Promise.all([
+                placeEntityId ? fetchEntityHistory(hass, placeEntityId, date) : [],
+                placeNameEntityId ? fetchEntityHistory(hass, placeNameEntityId, date) : [],
+                activityEntityId ? fetchEntityHistory(hass, activityEntityId, date) : [],
+            ]);
 
             const baseSegments = segmentTimeline(points, config, zones);
-            resolveStaySegments(baseSegments, placeStates, date, config.osm_api_key, onQueueUpdate);
+            resolveStaySegments(baseSegments, placeStates, placeNameStates, date, config.osm_api_key, onQueueUpdate);
             const segments = resolveActivities(baseSegments, activityStates, date, config.activity_icon_map, zones);
             return {entityId, placeEntityId, activityEntityId, points, segments};
         }),

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,17 +175,41 @@ export function normalizeEntityEntries(config, hass = null) {
             }
         });
 
-        for (const entry of entries) {
-            if (!entry.places_entity) {
-                const fallbackPlace = topLevelPlacesMap.get(entry.entity);
-                if (fallbackPlace) {
-                    entry.places_entity = fallbackPlace;
-                }
+        const attributeMatched = new Set(topLevelPlacesMap.values());
+        entries.forEach((entry, index) => {
+            if (entry.places_entity) return;
+            const fallbackPlace = topLevelPlacesMap.get(entry.entity);
+            if (fallbackPlace) {
+                entry.places_entity = fallbackPlace;
+                return;
+            }
+            // Places v3 no longer exposes devicetracker_entityid; fall back to the
+            // documented same-length/order mapping between both lists.
+            if (placeEntityIds.length === entries.length && placeEntityIds[index] && !attributeMatched.has(placeEntityIds[index])) {
+                entry.places_entity = placeEntityIds[index];
+            }
+        });
+    }
+
+    return entries;
+}
+
+export function resolvePlaceNameEntity(hass, placeEntityId) {
+    if (!hass || !placeEntityId) return null;
+    if (placeEntityId.endsWith("_place_name")) return null;
+
+    const registry = hass.entities;
+    const deviceId = registry?.[placeEntityId]?.device_id;
+    if (deviceId) {
+        for (const [entityId, entry] of Object.entries(registry)) {
+            if (entityId !== placeEntityId && entry?.device_id === deviceId && entityId.endsWith("_place_name")) {
+                return entityId;
             }
         }
     }
 
-    return entries;
+    const conventionId = `${placeEntityId}_place_name`;
+    return hass.states?.[conventionId] ? conventionId : null;
 }
 
 export function formatErrorMessage(err) {


### PR DESCRIPTION
## Summary

The [Places integration](https://github.com/custom-components/places) is releasing v3 (currently in beta, `v3.0.0-beta.3`) with a breaking change: attributes such as `place_name` move from the main sensor to separate child sensors per attribute, and the `devicetracker_entityid` attribute is removed entirely. This PR makes the card work with both Places v2 and v3, with no configuration changes required for users.

## Changes

- **Place name resolution (v3):** new `resolvePlaceNameEntity()` helper in `utils.js` finds the `..._place_name` child sensor belonging to the configured Places sensor via the entity registry (`hass.entities` device match), with a naming-convention fallback. `segmentation.js` fetches its history alongside the main sensor, and `reverse-geocoding.js` prefers the child sensor's states for stay names — falling back to the v2 attributes so history recorded before the upgrade keeps resolving correctly (including mixed v2/v3 transition days).
- **Auto-matching of top-level `places_entity` lists:** v2 matching by the `devicetracker_entityid` attribute is kept and still takes precedence; when the attribute is missing (v3), entries are matched by list position, per the already-documented same-length/order contract.
- **Docs:** new "Places v3 compatibility" section in `README.md` and updated resolution steps in `advanced.md`.

## Testing

- `npm run build` passes.
- Logic verified with Node assertions (bundled via Rollup) covering: registry lookup + convention fallback, v2 attribute matching (including cross-order lists), v3 positional matching, mixed v2/v3 setups, length-mismatch (no assignment), explicit per-entity overrides, child-sensor precedence over the v3 display state, `unknown`/`unavailable` child states, and v2→v3 transition days.
- Not yet verified end-to-end against a live HA instance with the Places v3 beta — recommended before release.

## Release note

Places v3 is still in beta; the `_place_name` entity suffix and default-enabled child sensors could theoretically change before the final release. Consider tagging the card release once Places v3.0.0 is final, or marking it explicitly as beta-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)