### PR TITLE
fix: don't show raw Places v3 display-options strings as addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Places v3 is a breaking change in the Places integration itself: attributes such
 - With a top-level `places_entity` list, v2 sensors are matched to trackers via their `devicetracker_entityid` attribute. That attribute no longer exists in v3, so the card falls back to matching by list position — make sure the list has the same length and order as `entity` (as was already documented).
 - History from before the v3 upgrade keeps working: for those periods the card still reads the old attributes.
 - The main v3 sensor's state is not an address but the string built from your Places *display options*. The card only uses it when it reads as a name (e.g. with the `formatted_place` option); a raw field list such as `not_home, house, 13, Beatrixstraat` is ignored, and the stay is named from the `..._place_name` sensor or from reverse geocoding (`osm_api_key`) instead.
+- Places' `show_time` option appends `(since HH:MM)` to the state, or `(since MM/DD)` once it is over a day old. Both are stripped before the name is used, so stays are not labelled with the moment the sensor happened to change.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Places v3 is a breaking change in the Places integration itself: attributes such
 - Keep pointing `places_entity` at the **main** Places sensor. On v3, the card automatically detects and reads the `..._place_name` child sensor (enabled by default in Places v3). Pointing `places_entity` directly at the `..._place_name` sensor also works.
 - With a top-level `places_entity` list, v2 sensors are matched to trackers via their `devicetracker_entityid` attribute. That attribute no longer exists in v3, so the card falls back to matching by list position — make sure the list has the same length and order as `entity` (as was already documented).
 - History from before the v3 upgrade keeps working: for those periods the card still reads the old attributes.
+- The main v3 sensor's state is not an address but the string built from your Places *display options*. The card only uses it when it reads as a name (e.g. with the `formatted_place` option); a raw field list such as `not_home, house, 13, Beatrixstraat` is ignored, and the stay is named from the `..._place_name` sensor or from reverse geocoding (`osm_api_key`) instead.
 
 ## Notes
 

--- a/src/reverse-geocoding.js
+++ b/src/reverse-geocoding.js
@@ -13,6 +13,12 @@ const V2_ADDRESS_ATTRIBUTES = ["place_name", "street", "street_number", "city", 
 // `secondary`, `charging_station`) or a bare house number (`13`, `2a`).
 const RAW_OPTION_TOKEN = /^([a-z][a-z0-9]*(_[a-z0-9]+)*|\d+[a-z]?)$/;
 
+// Places appends this when its `show_time` option is on, swapping the time for a date
+// once the state is over a day old. Both forms are plain f-strings in the integration,
+// never translated, so matching `since` literally is safe. Same pattern as Places' own
+// `helpers.clear_since_from_state`; the `[:/]` class is what covers the date form.
+const SINCE_SUFFIX = /\s*\(since \d\d[:/]\d\d\)$/;
+
 let reverseGeocodingConfig = {
     nominatim_reverse_url: "https://nominatim.openstreetmap.org/reverse",
     request_interval_ms: 1000,
@@ -178,17 +184,26 @@ function buildIntervals(states, date, displayNameFn) {
 
 function placeDisplayName(state) {
     const attrs = state.a || {};
+    // Stripped up front so both branches are free of it: `show_time` is a Places option,
+    // not a v3 one, so a v2 sensor falling through to its state carries the suffix too.
+    const sensorState = stripSinceSuffix(state.s);
+
     if (V2_ADDRESS_ATTRIBUTES.some((key) => attrs[key])) {
         const streetAddress = [attrs.street, attrs.street_number].filter(Boolean).join(" ");
         const formatted_address = streetAddress ? [streetAddress, attrs.city].filter(Boolean).join(", ") : null;
-        return attrs.place_name || formatted_address || state.s || attrs.formatted_address || null;
+        return attrs.place_name || formatted_address || sensorState || attrs.formatted_address || null;
     }
 
     // Places v3: no address attributes left, so the state is whatever the user's display
     // options render. With `formatted_place` that is a readable name, but a plain field
     // list yields raw OSM tokens ("not_home, house, 13, Beatrixstraat"), which must not be
     // shown as an address — fall through to the place_name sensor or reverse geocoding.
-    return cleanDisplayOptionsState(state.s);
+    return cleanDisplayOptionsState(sensorState);
+}
+
+function stripSinceSuffix(value) {
+    if (typeof value !== "string") return value;
+    return value.trim().replace(SINCE_SUFFIX, "");
 }
 
 function cleanDisplayOptionsState(value) {

--- a/src/reverse-geocoding.js
+++ b/src/reverse-geocoding.js
@@ -5,6 +5,14 @@ const LOADING_LOCATION = "Loading address...";
 const PERSISTENT_CACHE_KEY = "location_timeline_reverse_geocode_cache_v1";
 const MAX_PERSISTENT_CACHE_ENTRIES = 300;
 
+// Attributes that only Places v2 puts on the main sensor. Places v3 moved all of them
+// to child sensors, leaving the main sensor with just coordinates.
+const V2_ADDRESS_ATTRIBUTES = ["place_name", "street", "street_number", "city", "formatted_address", "formatted_place", "devicetracker_entityid"];
+
+// A single display-option field rendered raw by Places: an OSM token (`not_home`, `house`,
+// `secondary`, `charging_station`) or a bare house number (`13`, `2a`).
+const RAW_OPTION_TOKEN = /^([a-z][a-z0-9]*(_[a-z0-9]+)*|\d+[a-z]?)$/;
+
 let reverseGeocodingConfig = {
     nominatim_reverse_url: "https://nominatim.openstreetmap.org/reverse",
     request_interval_ms: 1000,
@@ -170,14 +178,38 @@ function buildIntervals(states, date, displayNameFn) {
 
 function placeDisplayName(state) {
     const attrs = state.a || {};
-    const formatted_address = attrs.street ? `${attrs.street} ${attrs.street_number || ""}, ${attrs.city}` : null;
-    return attrs.place_name || formatted_address || state.s || attrs.formatted_address || null;
+    if (V2_ADDRESS_ATTRIBUTES.some((key) => attrs[key])) {
+        const streetAddress = [attrs.street, attrs.street_number].filter(Boolean).join(" ");
+        const formatted_address = streetAddress ? [streetAddress, attrs.city].filter(Boolean).join(", ") : null;
+        return attrs.place_name || formatted_address || state.s || attrs.formatted_address || null;
+    }
+
+    // Places v3: no address attributes left, so the state is whatever the user's display
+    // options render. With `formatted_place` that is a readable name, but a plain field
+    // list yields raw OSM tokens ("not_home, house, 13, Beatrixstraat"), which must not be
+    // shown as an address — fall through to the place_name sensor or reverse geocoding.
+    return cleanDisplayOptionsState(state.s);
+}
+
+function cleanDisplayOptionsState(value) {
+    const text = normalizeSensorState(value);
+    if (!text || looksLikeRawDisplayOptions(text)) return null;
+    return text.split(",").map((part) => part.trim()).filter(Boolean).join(", ");
+}
+
+function looksLikeRawDisplayOptions(name) {
+    const parts = String(name).split(",").map((part) => part.trim()).filter(Boolean);
+    return !parts.length || parts.some((part) => RAW_OPTION_TOKEN.test(part));
 }
 
 function placeNameSensorDisplayName(state) {
-    const value = typeof state.s === "string" ? state.s.trim() : "";
-    if (!value || value === "unknown" || value === "unavailable") return null;
-    return value;
+    return normalizeSensorState(state.s);
+}
+
+function normalizeSensorState(value) {
+    const text = typeof value === "string" ? value.trim() : "";
+    if (!text || text === "unknown" || text === "unavailable" || text === "none") return null;
+    return text;
 }
 
 function pickPlaceName(intervals, start, end) {
@@ -212,7 +244,9 @@ function loadPersistentCache() {
         if (!raw) return new Map();
         const parsed = JSON.parse(raw);
         if (!Array.isArray(parsed)) return new Map();
-        return new Map(parsed);
+        // Drop entries cached before raw Places v3 display-options strings were rejected,
+        // otherwise those names keep being served from the cache forever.
+        return new Map(parsed.filter(([, value]) => !looksLikeRawDisplayOptions(value?.placeName || "")));
     } catch {
         return new Map();
     }


### PR DESCRIPTION
## Problem

After upgrading to Places v3, stays could be labelled with a raw string such as `not_home, house, 13, Schoolstraat` instead of a readable address.

On v3 the main Places sensor keeps **no** address attributes (only `latitude`/`longitude`/`gps_accuracy`), and its state is whatever the configured *display options* render. With a plain field list (e.g. `zone_name, place`) that state is a raw, comma-joined list of OSM values. The v2 compatibility path in `placeDisplayName()` still ended in `|| state.s`, so whenever the `..._place_name` child sensor was `unknown` (which it is for anything that is not a named POI) that raw string became the stay name.

Installs using the `formatted_place` display option were unaffected, which is why this only showed up for some sensors.

## Changes

- `placeDisplayName()` takes the v2 attribute path only for records that actually carry those attributes, so history from before the upgrade keeps rendering exactly as it did.
- On v3, the sensor state is accepted only when it reads as a name (e.g. `formatted_place`). A string containing raw OSM tokens (`not_home`, `house`, `secondary`, `charging_station`) or bare house numbers (`13`, `2a`) is rejected, so the stay falls through to the `..._place_name` sensor or to reverse geocoding and gets the card's own `Street 13, City` formatting.
- Prune raw display-options strings that were already written to the persistent reverse-geocode cache in `localStorage` — otherwise the bad name keeps being served from cache after the fix.
- Drop the stray space/comma a v2 record produced when it had a street but no street number.
- Document the v3 display-options behaviour in the README's Places v3 section.

## Testing

Exercised `resolveStaySegments()` against states taken from a real Places v3 history:

| Input | Result |
| --- | --- |
| v3 state `not_home, house, 13, Beatrixstraat`, `place_name` unknown | falls through to reverse geocoding |
| v3 state raw, `place_name` = `Albert Heijn` | `Albert Heijn` |
| v3 `formatted_place` state | kept unchanged |
| v2 record with `street`/`street_number`/`city` attributes | `Schoolstraat 13, Amsterdam` (unchanged) |
| cache entry holding a raw string | dropped and re-resolved |
| cache entry holding a normal address | kept |

---
_Generated by [Claude Code](https://claude.ai/code/session_017RNxx6gtBzghrdpYvKjCHf)_