### PR TITLE
feat: render the base map from OSM vector tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ When multiple entities are configured, the card renders all tracks on the map an
 | `distance_unit`             | string   | `"metric"`   | Distance unit for moving segments: `metric` (m, km) or `imperial` (ft, mi).                                                                                             |
 | `map_appearance`            | string   | `"auto"`     | Map appearance: `auto` (align with HA theme), `light`, or `dark`.                                                                                                       |
 | `map_height_px`             | number   | `200`        | Height of the map area in pixels.                                                                                                                                       |
+| `map_tile_url`              | string   | `null`       | Raster tile URL template for the fallback base map (see [Base map](#base-map)). Only used when vector tiles are unavailable.                                             |
+| `map_attribution`           | string   | `null`       | Attribution shown for a custom `map_tile_url`. Defaults to OpenStreetMap.                                                                                               |
 | `hide_current_location`     | boolean  | `false`      | Hide the current location when viewing today.                                                                                                                           |
 | `hide_unselected_on_map`    | boolean  | `false`      | Fully hide non-selected entities' tracks/markers on the map instead of dimming them. Only the selected entity is shown.                                                 |
 | `hide_moving`               | boolean  | `false`      | Hide moving rows and keep only stays.                                                                                                                                   |
@@ -150,6 +152,23 @@ Places v3 is a breaking change in the Places integration itself: attributes such
 - Keep pointing `places_entity` at the **main** Places sensor. On v3, the card automatically detects and reads the `..._place_name` child sensor (enabled by default in Places v3). Pointing `places_entity` directly at the `..._place_name` sensor also works.
 - With a top-level `places_entity` list, v2 sensors are matched to trackers via their `devicetracker_entityid` attribute. That attribute no longer exists in v3, so the card falls back to matching by list position — make sure the list has the same length and order as `entity` (as was already documented).
 - History from before the v3 upgrade keeps working: for those periods the card still reads the old attributes.
+
+## Base map
+
+The card draws the base map the same way Home Assistant's own map does since 2026.9: [Shortbread vector tiles](https://vector.openstreetmap.org/) from the OpenStreetMap Foundation, rendered with MapLibre GL. The style, glyphs and sprites are the ones Home Assistant serves at `/static/map/`, so nothing extra is downloaded from a third party and dark mode uses a real dark style instead of an inverted light one.
+
+The card falls back to raster tiles when those assets are missing (Home Assistant older than 2026.9) or when the browser has no WebGL2. That fallback is CARTO's raster service, which now watermarks tiles requested without an API key and is being retired. Two ways out on an older Home Assistant:
+
+```yaml
+# Your own free CARTO key (https://carto.com/basemaps/apikey)
+map_tile_url: https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png?key=YOUR_KEY
+```
+
+```yaml
+# Or any other raster tile server
+map_tile_url: https://tile.example.org/{z}/{x}/{y}.png
+map_attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+```
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@maplibre/maplibre-gl-leaflet": "^0.1.4",
         "custom-card-helpers": "^1.9.0",
-        "leaflet": "^1.9.4"
+        "leaflet": "^1.9.4",
+        "maplibre-gl": "^5.24.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.2",
@@ -95,6 +97,130 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-leaflet": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-leaflet/-/maplibre-gl-leaflet-0.1.4.tgz",
+      "integrity": "sha512-k57wcndZIvq3m08g2je4pjUPGr43ffNW3j+gXbymt8Vi2l1lUERUi1UmdTZcTPN8LuDDYOMWRNBaSLwpAu02ew==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@types/leaflet": "^1.9.0",
+        "leaflet": "^1.9.3",
+        "maplibre-gl": "^2.4.0 || ^3.3.1 || ^4.3.2 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.0.tgz",
+      "integrity": "sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -550,6 +676,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.22.tgz",
+      "integrity": "sha512-h3lhECYEKDasG7LFHu+GiHqAvsgLuQvlJvVZzJDGONo3sEL+wUOqSFLnwkZlK0qVxnxbuGFW8iBlJNYs5wgndA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -610,6 +752,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -667,6 +815,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -732,6 +886,18 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
@@ -779,12 +945,73 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
@@ -798,6 +1025,24 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -818,6 +1063,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/rollup": {
@@ -899,6 +1153,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "rollup-plugin-import-css": "^3.5.8"
   },
   "dependencies": {
+    "@maplibre/maplibre-gl-leaflet": "^0.1.4",
     "custom-card-helpers": "^1.9.0",
-    "leaflet": "^1.9.4"
+    "leaflet": "^1.9.4",
+    "maplibre-gl": "^5.24.0"
   }
 }

--- a/src/card.css
+++ b/src/card.css
@@ -331,6 +331,10 @@ ha-card {
 
 #overview-map.dark {
   background: #090909;
+}
+
+/* Vector tiles have a real dark style, so only raster tiles are inverted. */
+#overview-map.dark.raster-tiles {
   --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5) contrast(1.2) saturate(0.3);
 }
 

--- a/src/card.js
+++ b/src/card.js
@@ -1,5 +1,6 @@
 import css from "./card.css";
 import leafletCss from "leaflet/dist/leaflet.css";
+import maplibreCss from "maplibre-gl/dist/maplibre-gl.css";
 import {getSegmentedTracks} from "./segmentation.js";
 import {
     escapeHtml,
@@ -28,6 +29,8 @@ const DEFAULT_CONFIG = {
     max_reasonable_speed_kmh: 300,
     map_appearance: "auto",
     map_height_px: 200,
+    map_tile_url: null,
+    map_attribution: null,
     distance_unit: "metric",
     colors: [],
     hide_current_location: false,
@@ -249,7 +252,7 @@ class TimelineCard extends HTMLElement {
         this._baseLayoutReady = true;
 
         this.shadowRoot.innerHTML = `
-          <style>${css}\n${leafletCss}</style>
+          <style>${css}\n${leafletCss}\n${maplibreCss}</style>
           <ha-card>
             <div class="card">
               <div class="map-wrap">
@@ -339,7 +342,10 @@ class TimelineCard extends HTMLElement {
 
         this._isLoadingMap = true;
         try {
-            this._mapView = new TimelineLeafletMap(container, this._getHomeZoneCenter());
+            this._mapView = new TimelineLeafletMap(container, this._getHomeZoneCenter(), {
+                mapTileUrl: this._config.map_tile_url,
+                mapAttribution: this._config.map_attribution,
+            });
             this._setDarkMode();
             this._drawMapPaths();
         } catch (err) {

--- a/src/card.js
+++ b/src/card.js
@@ -57,6 +57,7 @@ class TimelineCard extends HTMLElement {
         this._activeEntityIndex = 0;
         this._timelineCollapsed = false;
         this._updateIntervalId = null;
+        this._teardownTimeout = null;
         this._resetMapFitMode();
         this._addEventListeners();
     }
@@ -114,6 +115,8 @@ class TimelineCard extends HTMLElement {
 
     // noinspection JSUnusedGlobalSymbols
     connectedCallback() {
+        clearTimeout(this._teardownTimeout);
+        this._teardownTimeout = null;
         if (!this._config) return;
         // disconnectedCallback stops the interval and setConfig is the only other place that
         // starts one, so without this a card that Home Assistant re-attaches never refreshes.
@@ -131,8 +134,19 @@ class TimelineCard extends HTMLElement {
 
         // ha-map has always done this; the card never has. Without it every replaced card
         // strands a WebGL context, and browsers cap how many may live at once.
-        this._mapView?.destroy();
-        this._mapView = null;
+        //
+        // Deferred by a task, which is the one place this departs from ha-map: Home Assistant
+        // moves cards around the DOM and a move arrives here as a disconnect immediately
+        // followed by a reconnect. Tearing down synchronously would drop and rebuild the
+        // context, and refetch the style, on every move. A view's map is not moved that way,
+        // so ha-map has no such case to handle.
+        clearTimeout(this._teardownTimeout);
+        this._teardownTimeout = setTimeout(() => {
+            this._teardownTimeout = null;
+            if (this.isConnected) return;
+            this._mapView?.destroy();
+            this._mapView = null;
+        }, 0);
     }
 
     _checkConfig() {

--- a/src/card.js
+++ b/src/card.js
@@ -113,11 +113,26 @@ class TimelineCard extends HTMLElement {
     }
 
     // noinspection JSUnusedGlobalSymbols
+    connectedCallback() {
+        if (!this._config) return;
+        // disconnectedCallback stops the interval and setConfig is the only other place that
+        // starts one, so without this a card that Home Assistant re-attaches never refreshes.
+        this._setupUpdateInterval();
+        // Only after a teardown; the first map is attached by the render pass.
+        if (this._rendered && !this._mapView) this._attachMapCard();
+    }
+
+    // noinspection JSUnusedGlobalSymbols
     disconnectedCallback() {
         if (this._updateIntervalId) {
             clearInterval(this._updateIntervalId);
             this._updateIntervalId = null;
         }
+
+        // ha-map has always done this; the card never has. Without it every replaced card
+        // strands a WebGL context, and browsers cap how many may live at once.
+        this._mapView?.destroy();
+        this._mapView = null;
     }
 
     _checkConfig() {

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -134,6 +134,14 @@ export class TimelineLeafletMap {
             clearTimeout(this._fallbackTimeout);
         });
         document.addEventListener("visibilitychange", this._handleVisibilityChange);
+        // Tied to the map's own teardown rather than to a caller remembering, the same way
+        // the frontend does it: otherwise the timer revives a map that is already gone, and
+        // the listener keeps the whole graph — and its WebGL context — alive for the
+        // lifetime of the page.
+        this._leafletMap.on("unload", () => {
+            clearTimeout(this._fallbackTimeout);
+            document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        });
         return true;
     }
 

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -1,10 +1,62 @@
 import Leaflet from "leaflet";
+import {maplibreGL} from "@maplibre/maplibre-gl-leaflet";
 import {getTrackColor} from "./utils.js";
 
 const DEFAULT_ZOOM = 13;
+const MAP_MIN_ZOOM = 1;
+const MAP_MAX_ZOOM = 20;
+
+// Shortbread vector tiles from the OpenStreetMap Foundation, through the style,
+// glyphs and sprites the Home Assistant frontend serves itself (2026.9 and up).
+// Older installs have no /static/map, so the raster layer stays as a fallback.
+const VECTOR_STYLES = {
+    light: "/static/map/light.json",
+    dark: "/static/map/dark.json",
+};
+
+// Fallback only: CARTO watermarks tiles requested without an API key and is
+// retiring this service, so `map_tile_url` exists to point somewhere else (or at
+// the same URL with `?key=...` appended).
+const RASTER_TILE_URL = "https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png";
+const OSM_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+const CARTO_ATTRIBUTION = `${OSM_ATTRIBUTION}, &copy; <a href="https://carto.com/attributions">CARTO</a>`;
+
+// A backgrounded tab also drops the WebGL context, and that one comes back, so
+// only a loss that outlives the grace period falls back to raster tiles.
+const CONTEXT_RESTORE_GRACE = 2000;
+
+let webGL2Supported;
+
+function supportsWebGL2() {
+    if (webGL2Supported === undefined) {
+        try {
+            const context = document.createElement("canvas").getContext("webgl2");
+            webGL2Supported = Boolean(context);
+            // Contexts are scarce, so the probe must not hold on to one.
+            context?.getExtension("WEBGL_lose_context")?.loseContext();
+        } catch {
+            webGL2Supported = false;
+        }
+    }
+    return webGL2Supported;
+}
+
+// MapLibre rejects a relative sprite URL, while the glyph URL must be left alone:
+// encoding it would mangle its {fontstack} and {range} placeholders.
+async function loadMapStyle(url) {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Map style ${url} unavailable (${response.status})`);
+    const style = await response.json();
+    if (typeof style.sprite === "string") {
+        style.sprite = new URL(style.sprite, location.href).href;
+    } else if (Array.isArray(style.sprite)) {
+        style.sprite = style.sprite.map((sprite) => ({...sprite, url: new URL(sprite.url, location.href).href}));
+    }
+    return style;
+}
 
 export class TimelineLeafletMap {
-    constructor(mapElement, homeZoneCenter = null) {
+    constructor(mapElement, homeZoneCenter = null, options = {}) {
         if (!mapElement?.isConnected) {
             throw new Error("Cannot setup Leaflet map on disconnected element");
         }
@@ -12,18 +64,23 @@ export class TimelineLeafletMap {
         this._Leaflet = Leaflet;
         this._mapElement = mapElement;
         this._homeZoneCenter = homeZoneCenter;
-        this._leafletMap = Leaflet.map(mapElement, {zoomControl: true});
+        this._leafletMap = Leaflet.map(mapElement, {zoomControl: true, minZoom: MAP_MIN_ZOOM, maxZoom: MAP_MAX_ZOOM});
 
-        const attribution =
-            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>';
-        const tileLayer = Leaflet.tileLayer(`https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png`, {
-            attribution,
-            subdomains: "abcd",
-            minZoom: 0,
-            maxZoom: 20,
-            referrerPolicy: "no-referrer-when-downgrade",
-        });
-        tileLayer.addTo(this._leafletMap);
+        this._rasterTileUrl = options.mapTileUrl || RASTER_TILE_URL;
+        this._rasterAttribution = options.mapAttribution
+            || (options.mapTileUrl ? OSM_ATTRIBUTION : CARTO_ATTRIBUTION);
+        this._vectorLayer = null;
+        this._destroyed = false;
+        this._darkMode = false;
+        this._styleRequest = 0;
+        this._appliedDarkMode = false;
+        this._contextLost = false;
+        this._fallbackTimeout = undefined;
+        this._handleVisibilityChange = () => {
+            if (this._contextLost) this._scheduleRasterFallback();
+        };
+        // Deferred so the caller's setDarkMode() lands before the style is picked.
+        Promise.resolve().then(() => this._setupBaseLayer());
 
         if (this._homeZoneCenter) this._leafletMap.setView(this._homeZoneCenter, DEFAULT_ZOOM);
 
@@ -39,11 +96,103 @@ export class TimelineLeafletMap {
         requestAnimationFrame(() => this._leafletMap.invalidateSize());
     }
 
+    async _setupBaseLayer() {
+        if (this._destroyed) return;
+        if (supportsWebGL2() && (await this._createVectorLayer())) return;
+        this._createRasterLayer();
+    }
+
+    async _createVectorLayer() {
+        let layer;
+        try {
+            const style = await loadMapStyle(VECTOR_STYLES[this._darkMode ? "dark" : "light"]);
+            if (this._destroyed) return false;
+            layer = maplibreGL({style, localIdeographFontFamily: "sans-serif"});
+            // The adapter builds the MapLibre map in `onAdd`, so a refused context or a
+            // blocked worker throws here — inside the guard, or raster is never reached.
+            layer.addTo(this._leafletMap);
+        } catch {
+            try {
+                layer?.remove();
+            } catch {
+                // May never have finished being added.
+            }
+            return false;
+        }
+
+        this._vectorLayer = layer;
+        this._appliedDarkMode = this._darkMode;
+        this._mapElement?.classList.remove("raster-tiles");
+
+        const glMap = layer.getMaplibreMap();
+        glMap.on("webglcontextlost", () => {
+            this._contextLost = true;
+            this._scheduleRasterFallback();
+        });
+        glMap.on("webglcontextrestored", () => {
+            this._contextLost = false;
+            clearTimeout(this._fallbackTimeout);
+        });
+        document.addEventListener("visibilitychange", this._handleVisibilityChange);
+        return true;
+    }
+
+    _createRasterLayer() {
+        if (this._destroyed) return;
+        this._mapElement?.classList.add("raster-tiles");
+        Leaflet.tileLayer(this._rasterTileUrl, {
+            attribution: this._rasterAttribution,
+            subdomains: "abcd",
+            minZoom: MAP_MIN_ZOOM,
+            maxZoom: MAP_MAX_ZOOM,
+            referrerPolicy: "no-referrer-when-downgrade",
+        }).addTo(this._leafletMap);
+    }
+
+    _scheduleRasterFallback() {
+        clearTimeout(this._fallbackTimeout);
+        if (!this._vectorLayer || document.hidden) return;
+        this._fallbackTimeout = setTimeout(() => this._swapToRaster(), CONTEXT_RESTORE_GRACE);
+    }
+
+    _swapToRaster() {
+        const layer = this._vectorLayer;
+        this._vectorLayer = null;
+        document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        try {
+            layer?.remove();
+        } catch {
+            // Nothing left to detach.
+        }
+        this._createRasterLayer();
+        // The raster layer has no dark variant; the CSS filter takes over again.
+        this._mapElement?.classList.toggle("dark", this._darkMode);
+    }
+
     setDarkMode(isDarkMode) {
-        this._mapElement?.classList.toggle("dark", Boolean(isDarkMode));
+        const darkMode = Boolean(isDarkMode);
+        this._darkMode = darkMode;
+        this._mapElement?.classList.toggle("dark", darkMode);
+        if (!this._vectorLayer || darkMode === this._appliedDarkMode) return;
+
+        // Styles are fetched, so only the newest request may touch the map.
+        const request = ++this._styleRequest;
+        loadMapStyle(VECTOR_STYLES[darkMode ? "dark" : "light"])
+            .then((style) => {
+                if (request !== this._styleRequest || !this._vectorLayer) return;
+                this._appliedDarkMode = darkMode;
+                this._vectorLayer.getMaplibreMap()?.setStyle(style);
+            })
+            .catch(() => {
+                // Keep showing the style that is up; the next toggle retries.
+            });
     }
 
     destroy() {
+        this._destroyed = true;
+        clearTimeout(this._fallbackTimeout);
+        document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        this._vectorLayer = null;
         this._leafletMap.remove();
         this._mapLayers = [];
         this._fullDayPath = [];


### PR DESCRIPTION
## Problem

The map is covered in an `API KEY REQUIRED — carto.com/basemaps/apikey` watermark. CARTO started requiring an API key for its raster basemaps at `basemaps.cartocdn.com` and watermarks unauthenticated tiles; the service is also being retired.

Home Assistant hit exactly the same wall ([core#180277](https://github.com/home-assistant/core/issues/180277), [frontend#53800](https://github.com/home-assistant/frontend/issues/53800)) and answered it in 2026.9 ([frontend#53816](https://github.com/home-assistant/frontend/pull/53816)): Shortbread vector tiles from the OpenStreetMap Foundation rendered with MapLibre GL, with Leaflet kept for markers and clustering, and CARTO raster demoted to a WebGL-less fallback.

## Changes

This card follows the same route, and because it runs inside the frontend it can reuse the style, glyphs and sprites Home Assistant already serves at `/static/map/` — no map assets are shipped with the card and the base map matches the built-in one.

- Add a MapLibre GL base layer via `@maplibre/maplibre-gl-leaflet`, used when the browser has WebGL2 and `/static/map/light.json` loads.
- Keep a Leaflet raster layer as fallback for Home Assistant older than 2026.9 and browsers without WebGL2, and swap back to it when a lost WebGL context is not restored within a grace period.
- Dark mode now switches to the dark vector style. The CSS inversion filter is scoped to the raster layer (`#overview-map.dark.raster-tiles`), which has no dark variant — the MapLibre canvas lives in the same Leaflet tile pane and would otherwise be inverted too.
- New options `map_tile_url` / `map_attribution` for the raster fallback, so it can point at CARTO with your own free API key (`?key=...`) or at a different tile server. Documented in a new **Base map** README section.
- Zoom limits moved from the tile layer to the map (min 1, max 20): the adapter drives MapLibre to zoom -1 at Leaflet zoom 0.

## Trade-off

The bundle grows from **134 kB to 418 kB gzipped** (581 kB → 1.73 MB raw); that is MapLibre GL. It is a static import because the card ships as a single file.

## Testing

Driven in headless Chromium against a local server:

| Scenario | Result |
| --- | --- |
| `/static/map/*.json` present, WebGL2 available | MapLibre canvas rendered, no `raster-tiles` class, no page errors |
| `setDarkMode(true)` before the layer resolves | dark style picked for the initial load |
| toggle back to light | style swapped to the light one |
| `/static/map` missing (pre-2026.9) | raster fallback: Leaflet tiles requested, `raster-tiles` class set, CARTO attribution shown |

---
_Generated by [Claude Code](https://claude.ai/code/session_017RNxx6gtBzghrdpYvKjCHf)_