### PR TITLE
Animation on timeline path, interactive timeline & map, and layout configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,28 @@ When multiple entities are configured, the card renders all tracks on the map an
 | **Map display**             |          |              |                                                                                                                                                                         |
 | `distance_unit`             | string   | `"metric"`   | Distance unit for moving segments: `metric` (m, km) or `imperial` (ft, mi).                                                                                             |
 | `map_appearance`            | string   | `"auto"`     | Map appearance: `auto` (align with HA theme), `light`, or `dark`.                                                                                                       |
-| `map_height_px`             | number   | `200`        | Height of the map area in pixels.                                                                                                                                       |
+| `map_height_px`             | number   | `200`        | Height of the map area in pixels. Ignored while `timeline_position` is `left`/`right` and showing two columns, where the map fills the available height instead.        |
+| `timeline_position`         | string   | `"bottom"`   | Position of the timeline list relative to the map: `top`, `bottom`, `left`, or `right`. `left`/`right` automatically collapse to a stacked layout on narrow cards (~600px or less).|
+| `timeline_size`             | number   | `30`         | Percentage width the timeline section occupies when `timeline_position` is `left` or `right`. Ignored for `top`/`bottom`. Clamped between `10` and `90`.                |
+| `pills_position`            | string   | `"below"`    | Position of the entity selector ("pills") row relative to the map: `above` or `below`.                                                                                  |
 | `hide_current_location`     | boolean  | `false`      | Hide the current location when viewing today.                                                                                                                           |
 | `hide_unselected_on_map`    | boolean  | `false`      | Fully hide non-selected entities' tracks/markers on the map instead of dimming them. Only the selected entity is shown.                                                 |
 | `hide_moving`               | boolean  | `false`      | Hide moving rows and keep only stays.                                                                                                                                   |
 | `reverse_timeline_order`    | boolean  | `false`      | Show timeline items from latest to earliest within the selected day.                                                                                                     |
 | `collapse_timeline`         | boolean  | `false`      | Start with the timeline section collapsed on first render.                                                                                                              |
 | `timeline_use_entity_color` | boolean  | `false`      | Use the active entity track color for the timeline spine/dots/text instead of always using HA `--primary-color`.                                                        |
+| `animate_highlighted_path`  | boolean  | `true`       | Animate ("marching ants") the currently-highlighted move segment's track to show direction of travel.                                                                   |
 | `colors`                    | string[] | `[]`         | Optional list of per-entity track colors. When set, these colors are used in order (cycled if needed) instead of HA `--primary-color`/`--color-x` variables.            |
 | **Misc**                    |          |              |                                                                                                                                                                         |
 | `update_interval`           | number   | `300`        | How often to refresh the card (in seconds).                                                                                                                             |
+
+## Map interactions
+
+- Hovering a timeline entry (desktop) highlights the matching segment on the map in orange. Clicking a **move** segment's row highlights it and pans/zooms the map to fit it.
+- A highlighted **move** segment animates ("marching ants") to show direction of travel when `animate_highlighted_path` is enabled (default).
+- Clicking a **stay** marker on the map opens a popup with the start/finish time at that location, plus the date if the stay spans more than one calendar day. Click it again, or click elsewhere on the map, to close it.
+- A popup closes whenever the map redraws, on the next hover or data refresh.
+- Clicking a **stay** marker or the selected entity's **route line** scrolls the timeline to the matching entry and briefly flashes it, expanding the list if collapsed. Clicking another entity's route line switches to that entity instead.
 
 ## Reverse Geocoding
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "module": "dist/timeline_card.js",
   "scripts": {
     "build": "rollup -c",
-    "dev": "rollup -c -w"
+    "dev": "rollup -c -w",
+    "test": "node --test"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.2",

--- a/src/card.css
+++ b/src/card.css
@@ -1,16 +1,91 @@
 :host {
   display: block;
+  height: 100%;
+  container-type: inline-size;
+  container-name: timeline-card;
   font-family: var(--ha-card-header-font-family, "Helvetica Neue", Arial, sans-serif);
 }
 
 ha-card {
+  height: 100%;
   overflow: hidden;
 }
 
 .card {
+  display: grid;
+  grid-template-areas: "map" "timeline";
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+}
+
+/* .card above IS the timeline-bottom layout, so that class needs no rule of its own. */
+.card.timeline-top {
+  grid-template-areas: "timeline" "map";
+  grid-template-rows: 1fr auto;
+}
+
+.map-pills-group {
+  grid-area: map;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.map-pills-group .map-wrap {
+  order: 1;
+}
+
+.map-pills-group .selector-row {
+  order: 2;
+}
+
+.map-pills-group.pills-above .map-wrap {
+  order: 2;
+}
+
+.map-pills-group.pills-above .selector-row {
+  order: 1;
+}
+
+/* Two-column layouts only exist above the breakpoint; below it the stacked .card rules stand. */
+@container timeline-card (width > 600px) {
+  /* Floor the grid: the map column is a pure percentage chain, so a collapsed or empty
+     timeline column would otherwise resolve the whole card to 0 and clip its own controls. */
+  .card.timeline-left,
+  .card.timeline-right {
+    min-height: var(--map-height);
+  }
+
+  .card.timeline-left {
+    grid-template-areas: "timeline map";
+    grid-template-columns: var(--timeline-size) 1fr;
+    grid-template-rows: 1fr;
+  }
+
+  .card.timeline-right {
+    grid-template-areas: "map timeline";
+    grid-template-columns: 1fr var(--timeline-size);
+    grid-template-rows: 1fr;
+  }
+
+  .card.timeline-left .map-pills-group,
+  .card.timeline-right .map-pills-group {
+    height: 100%;
+  }
+
+  /* Fill the column instead of using the configured map height. */
+  .card.timeline-left .map-wrap,
+  .card.timeline-right .map-wrap {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .card.timeline-left #overview-map,
+  .card.timeline-right #overview-map {
+    height: 100%;
+  }
 }
 
 .header {
@@ -116,6 +191,9 @@ ha-card {
 
 .timeline-section {
   display: grid;
+  grid-area: timeline;
+  min-width: 0;
+  min-height: 0;
   grid-template-rows: 1fr;
   transition:
     grid-template-rows 260ms ease,
@@ -125,6 +203,13 @@ ha-card {
 
 .timeline-content {
   overflow: hidden;
+}
+
+/* Panel views resolve a real height on every ancestor, so drop the .body cap the grid/stack case needs. */
+.card.panel-fill .timeline-content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .timeline-section.collapsed {
@@ -172,9 +257,15 @@ ha-card {
 
 .body {
   padding: 8px 16px 16px;
-  max-height: 420px;
+  max-height: var(--timeline-max-height, 420px);
   overflow: auto;
   touch-action: pan-y;
+}
+
+.card.panel-fill .body {
+  flex: 1 1 auto;
+  min-height: 0;
+  --timeline-max-height: none;
 }
 
 .loading,
@@ -325,8 +416,17 @@ ha-card {
 }
 
 #overview-map {
-  height: 200px;
+  height: var(--map-height, 200px);
   --map-filter: invert(0);
+}
+
+@container timeline-card (width <= 600px) {
+  /* Leaflet claims single-finger drags, so keep non-map area on screen to scroll the page with.
+     Scoped to the layouts this PR adds; bottom/top keep whatever map_height_px they always had. */
+  .card.timeline-left #overview-map,
+  .card.timeline-right #overview-map {
+    max-height: 50vh;
+  }
 }
 
 #overview-map.dark {
@@ -381,4 +481,54 @@ ha-card {
 .leaflet-top,
 .leaflet-bottom {
   z-index: 1 !important;
+}
+
+.timeline-marching-ants {
+  stroke-dasharray: 14 10;
+  animation: timeline-marching-ants 1s linear infinite;
+}
+
+/* -24px is the negated sum of the dash pattern above; keep the two in step.
+   Do not rewrite this as a calc() over custom properties: an unresolved calc() is not
+   interpolatable, so the dashes jump between endpoints once per cycle instead of sliding. */
+@keyframes timeline-marching-ants {
+  to {
+    stroke-dashoffset: -24px;
+  }
+}
+
+/* Leaflet draws popup chrome on a white background in both themes, so these stay dark on light
+   deliberately and are not wired to the HA theme like the rest of the card. */
+.timeline-popup-place {
+  font-weight: 600;
+  margin-bottom: 2px;
+  color: #212121;
+}
+
+.timeline-popup-time {
+  color: #555555;
+}
+
+.timeline-popup-date {
+  font-size: 0.8rem;
+  color: #777777;
+}
+
+.entry.map-focus {
+  background-color: color-mix(in srgb, var(--timeline-color, var(--primary-color)) 35%, transparent);
+  border-radius: 8px;
+}
+
+/* Lets _scrollTimelineToSegment call scrollTo() without picking a behavior itself. */
+.body {
+  scroll-behavior: smooth;
+}
+
+/* MAP_FOCUS_FLASH_MS in card.js must outlast this fade. */
+.entry {
+  transition: background-color 1.2s ease-out;
+}
+
+.entry.map-focus {
+  transition: background-color 0s;
 }

--- a/src/card.js
+++ b/src/card.js
@@ -2,22 +2,30 @@ import css from "./card.css";
 import leafletCss from "leaflet/dist/leaflet.css";
 import {getSegmentedTracks} from "./segmentation.js";
 import {
+    clampTimelineSize,
     escapeHtml,
     formatDate,
     formatErrorMessage,
     getTrackColor,
+    isSolePanelViewCard,
     isToday,
     normalizeEntityEntries,
     normalizeList,
     startOfDay,
+    TIMELINE_POSITIONS,
+    TIMELINE_SIZE,
     today,
     toLatLon,
+    validateLayoutConfig,
 } from "./utils.js";
 import {TimelineLeafletMap} from "./leaflet-map.js";
 import {clearPersistentCache, clearReverseGeocodingQueue} from "./reverse-geocoding.js";
 import {renderTimeline} from "./timeline.js";
 import {getConfigFormSchema} from "./config-flow.js";
 import {localize} from "./localize/localize.js";
+
+// Must outlast the .entry background-color fade in card.css.
+const MAP_FOCUS_FLASH_MS = 1600;
 
 const DEFAULT_CONFIG = {
     entity: [],
@@ -28,6 +36,10 @@ const DEFAULT_CONFIG = {
     max_reasonable_speed_kmh: 300,
     map_appearance: "auto",
     map_height_px: 200,
+    timeline_position: "bottom",
+    timeline_size: TIMELINE_SIZE.default,
+    pills_position: "below",
+    animate_highlighted_path: true,
     distance_unit: "metric",
     colors: [],
     hide_current_location: false,
@@ -54,6 +66,8 @@ class TimelineCard extends HTMLElement {
         this._activeEntityIndex = 0;
         this._timelineCollapsed = false;
         this._updateIntervalId = null;
+        this._flashTimeoutId = null;
+        this._flashRow = null;
         this._resetMapFitMode();
         this._addEventListeners();
     }
@@ -74,7 +88,6 @@ class TimelineCard extends HTMLElement {
         this._resetMapFitMode();
         this._setDarkMode();
         this._renderEntitySelector(true);
-        this._applyMapHeight();
         if (this._hass) {
             this._ensureDay(this._selectedDate);
         }
@@ -115,6 +128,11 @@ class TimelineCard extends HTMLElement {
             clearInterval(this._updateIntervalId);
             this._updateIntervalId = null;
         }
+        if (this._flashTimeoutId) {
+            clearTimeout(this._flashTimeoutId);
+            this._flashTimeoutId = null;
+        }
+        this._flashRow = null;
     }
 
     _checkConfig() {
@@ -130,6 +148,7 @@ class TimelineCard extends HTMLElement {
         if (!["auto", "light", "dark"].includes(this._config.map_appearance)) {
             throw new Error("map_appearance must be one of 'auto', 'light', or 'dark'");
         }
+        validateLayoutConfig(this._config);
     }
 
     _setDarkMode() {
@@ -142,10 +161,39 @@ class TimelineCard extends HTMLElement {
         this._mapView?.setDarkMode(darkMode);
     }
 
-    _applyMapHeight() {
-        const mapElement = this.shadowRoot?.getElementById("overview-map");
-        if (!mapElement) return;
-        mapElement.style.setProperty("height", `${this._config.map_height_px}px`, "important");
+    _isSolePanelViewCard() {
+        const parent = this.parentElement;
+        // Panel views nest us in the light DOM, but fall back to the shadow host for other embeddings.
+        const grandparent = parent?.parentElement || parent?.getRootNode()?.host;
+        return isSolePanelViewCard(parent?.tagName, grandparent?.tagName);
+    }
+
+    _applyPanelHeight() {
+        const card = this.shadowRoot?.querySelector(".card");
+        if (!card) return;
+        const isPanel = this._isSolePanelViewCard();
+        card.classList.toggle("panel-fill", isPanel);
+        if (!isPanel) return;
+        // Contain hui-card: its own parent is a flex item with min-height:auto, so an uncontained
+        // list grows the page instead of scrolling inside the card.
+        Object.assign(this.parentElement.style, {display: "block", height: "100%", contain: "size"});
+    }
+
+    _applyLayoutClasses() {
+        const card = this.shadowRoot?.querySelector(".card");
+        if (!card) return;
+        const {timeline_position, timeline_size, pills_position, map_height_px} = this._config;
+        TIMELINE_POSITIONS.forEach((position) =>
+            card.classList.toggle(`timeline-${position}`, position === timeline_position),
+        );
+        card.style.setProperty("--timeline-size", `${clampTimelineSize(timeline_size)}%`);
+        // Coerce before interpolating: "nullpx" is a valid custom-property token, so it would
+        // satisfy the var() fallback and then collapse the map to 0. Number(null) is 0, so
+        // require a positive number rather than just a finite one.
+        const mapHeight = Number(map_height_px);
+        const resolvedMapHeight = mapHeight > 0 ? mapHeight : DEFAULT_CONFIG.map_height_px;
+        card.style.setProperty("--map-height", `${resolvedMapHeight}px`);
+        this.shadowRoot.getElementById("map-pills-group")?.classList.toggle("pills-above", pills_position === "above");
     }
 
     // Actions
@@ -203,6 +251,7 @@ class TimelineCard extends HTMLElement {
     _render() {
         if (!this.shadowRoot) return;
         this._ensureBaseLayout();
+        this._applyLayoutClasses();
 
         const dateKey = formatDate(this._selectedDate);
         const dayData = this._cache.get(dateKey) || {
@@ -222,7 +271,7 @@ class TimelineCard extends HTMLElement {
         this.shadowRoot
             .querySelector("[data-action='next']")
             .toggleAttribute("disabled", this._selectedDate >= today());
-        this._applyMapHeight();
+        this._applyPanelHeight();
 
         this._updateMapFitButton();
         this._updateCollapseButtons();
@@ -252,18 +301,20 @@ class TimelineCard extends HTMLElement {
           <style>${css}\n${leafletCss}</style>
           <ha-card>
             <div class="card">
-              <div class="map-wrap">
-                <div id="overview-map"></div>
-                <ha-icon-button id="map-fit-mode" class="map-reset" data-action="update-map-fit-mode"><ha-icon></ha-icon></ha-icon-button>
-                <ha-icon-button id="timeline-collapse-map" class="map-reset map-reset-left" data-action="toggle-timeline-collapse" hidden>
-                  <ha-icon></ha-icon>
-                </ha-icon-button>
-              </div>
-              <div class="selector-row" id="selector-row" hidden>
-                <ha-icon-button id="timeline-collapse-selector" class="selector-collapse" data-action="toggle-timeline-collapse">
-                  <ha-icon></ha-icon>
-                </ha-icon-button>
-                <div id="entity-selector" class="entity-selector"></div>
+              <div class="map-pills-group" id="map-pills-group">
+                <div class="map-wrap">
+                  <div id="overview-map"></div>
+                  <ha-icon-button id="map-fit-mode" class="map-reset" data-action="update-map-fit-mode"><ha-icon></ha-icon></ha-icon-button>
+                  <ha-icon-button id="timeline-collapse-map" class="map-reset map-reset-left" data-action="toggle-timeline-collapse" hidden>
+                    <ha-icon></ha-icon>
+                  </ha-icon-button>
+                </div>
+                <div class="selector-row" id="selector-row" hidden>
+                  <ha-icon-button id="timeline-collapse-selector" class="selector-collapse" data-action="toggle-timeline-collapse">
+                    <ha-icon></ha-icon>
+                  </ha-icon-button>
+                  <div id="entity-selector" class="entity-selector"></div>
+                </div>
               </div>
               <div id="timeline-section" class="timeline-section">
                 <div class="timeline-content">
@@ -356,15 +407,17 @@ class TimelineCard extends HTMLElement {
         try {
             const tracks = Array.isArray(dayData.tracks) ? dayData.tracks : [];
             if (!this._config.hide_current_location) {
-                this._mapView._currentLocations = this._getCurrentEntityLocations();
+                this._mapView.setCurrentLocations(this._getCurrentEntityLocations());
             }
-            this._mapView.setDaySegments(
-                tracks,
-                this._activeEntityIndex,
-                (entityIndex) => this._setActiveEntityIndex(entityIndex),
-                this._config.colors,
-                this._config.hide_unselected_on_map,
-            );
+            this._mapView.setLocale(this._hass?.locale);
+            this._mapView.setDaySegments(tracks, {
+                activeEntityIndex: this._activeEntityIndex,
+                onTrackClick: (entityIndex) => this._setActiveEntityIndex(entityIndex),
+                colors: this._config.colors,
+                hideUnselected: this._config.hide_unselected_on_map,
+                animateHighlightedPath: this._config.animate_highlighted_path,
+                onSegmentClick: (segmentIndex) => this._scrollTimelineToSegment(segmentIndex),
+            });
             this._touchStart = null;
 
             this._updateMapFitButton();
@@ -676,6 +729,39 @@ class TimelineCard extends HTMLElement {
             if (segmentPoints.length < 2) return;
             this._mapView?.fitMap(segmentPoints.map(toLatLon));
         }
+    }
+
+    _scrollTimelineToSegment(segmentIndex) {
+        if (!Number.isInteger(segmentIndex) || segmentIndex < 0) return;
+
+        const body = this.shadowRoot?.getElementById("timeline-body");
+        const row = body?.querySelector(`.entry[data-segment-index="${segmentIndex}"]`);
+        // No row exists when hide_moving is on and a move segment was clicked. Bail before the
+        // expand below, or that click would open the list with nothing to show.
+        if (!body || !row) return;
+
+        // Open the collapsed list: a map click is an explicit request to look at that row.
+        if (this._timelineCollapsed) {
+            this._timelineCollapsed = false;
+            this._updateCollapseButtons();
+        }
+
+        // Measure with rects: .timeline is positioned, so offsetTop escapes the scroll container.
+        const bodyRect = body.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        const delta = rowRect.top - bodyRect.top - (bodyRect.height - rowRect.height) / 2;
+        // Scroll the list itself; scrollIntoView would also scroll the page.
+        body.scrollTo({top: body.scrollTop + delta});
+
+        if (this._flashTimeoutId) clearTimeout(this._flashTimeoutId);
+        this._flashRow?.classList.remove("map-focus");
+        this._flashRow = row;
+        row.classList.add("map-focus");
+        this._flashTimeoutId = setTimeout(() => {
+            row.classList.remove("map-focus");
+            this._flashRow = null;
+            this._flashTimeoutId = null;
+        }, MAP_FOCUS_FLASH_MS);
     }
 
     _bindTimelineTouch(body) {

--- a/src/config-flow.js
+++ b/src/config-flow.js
@@ -1,3 +1,5 @@
+import {PILLS_POSITIONS, TIMELINE_POSITIONS, TIMELINE_SIZE} from "./utils.js";
+
 export function getConfigFormSchema() {
     return {
         schema: [
@@ -85,6 +87,40 @@ export function getConfigFormSchema() {
                         ],
                     },
                     {
+                        type: "grid",
+                        name: "",
+                        flatten: true,
+                        schema: [
+                            {
+                                name: "timeline_position",
+                                selector: {
+                                    select: {
+                                        options: TIMELINE_POSITIONS,
+                                        mode: "dropdown",
+                                    },
+                                },
+                            },
+                            {
+                                name: "pills_position",
+                                selector: {
+                                    select: {options: PILLS_POSITIONS, mode: "dropdown"},
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        name: "timeline_size",
+                        selector: {
+                            number: {
+                                min: TIMELINE_SIZE.min,
+                                max: TIMELINE_SIZE.max,
+                                step: 1,
+                                unit_of_measurement: "%",
+                                mode: "box",
+                            },
+                        },
+                    },
+                    {
                         name: "map_height_px",
                         selector: {number: {unit_of_measurement: "px"}},
                     },
@@ -106,7 +142,8 @@ export function getConfigFormSchema() {
                         schema: [
                             {name: "collapse_timeline", selector: {boolean: {}}},
                             {name: "timeline_use_entity_color", selector: {boolean: {}}},
-                        ]
+                            {name: "animate_highlighted_path", selector: {boolean: {}}},
+                        ],
                     },
                     {name: "colors", selector: {text: {multiple: true}}},
                     {

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -1,5 +1,5 @@
 import Leaflet from "leaflet";
-import {getTrackColor} from "./utils.js";
+import {buildStayPopupHtml, findNearestSegmentIndex, getStayEdgeOptions, getTrackColor} from "./utils.js";
 
 const DEFAULT_ZOOM = 13;
 
@@ -34,16 +34,31 @@ export class TimelineLeafletMap {
         this._highlightedPath = [];
         this._highlightedStay = null;
         this._isTravelHighlightActive = false;
+        this._animateHighlightedPath = true;
+        this._locale = null;
+        this._onSegmentClick = null;
 
         this.setDarkMode(false);
-        requestAnimationFrame(() => this._leafletMap.invalidateSize());
+        // Re-measure on any box change: the layout breakpoint, the entity selector row and the HA
+        // sidebar all resize the map without a window resize, which is all Leaflet tracks itself.
+        this._resizeObserver = new ResizeObserver(() => this._leafletMap.invalidateSize());
+        this._resizeObserver.observe(mapElement);
     }
 
     setDarkMode(isDarkMode) {
         this._mapElement?.classList.toggle("dark", Boolean(isDarkMode));
     }
 
+    setLocale(locale) {
+        this._locale = locale;
+    }
+
+    setCurrentLocations(locations) {
+        this._currentLocations = Array.isArray(locations) ? locations : [];
+    }
+
     destroy() {
+        this._resizeObserver?.disconnect();
         this._leafletMap.remove();
         this._mapLayers = [];
         this._fullDayPath = [];
@@ -53,20 +68,39 @@ export class TimelineLeafletMap {
         this._highlightedStay = null;
     }
 
-    setDaySegments(tracks = [], activeEntityIndex = 0, onTrackClick = null, colors = [], hideUnselected = false) {
+    setDaySegments(
+        tracks = [],
+        {
+            activeEntityIndex = 0,
+            onTrackClick = null,
+            colors = [],
+            hideUnselected = false,
+            animateHighlightedPath = true,
+            onSegmentClick = null,
+        } = {},
+    ) {
+        this._animateHighlightedPath = Boolean(animateHighlightedPath);
+        this._onSegmentClick = typeof onSegmentClick === "function" ? onSegmentClick : null;
         this._fullDayPaths = tracks
             .map((track, index) => {
                 const points = [];
+                // Tag vertices in a parallel array: move points are cached track data shared with the
+                // card, and this runs again on every hover highlight.
+                const segmentIndices = [];
                 const segments = Array.isArray(track?.segments) ? track.segments : [];
-                segments.forEach((segment) => {
+                segments.forEach((segment, segmentIndex) => {
                     if (segment?.type === "stay" && segment.center) {
                         points.push({
                             point: [segment.center.lat, segment.center.lon],
                             timestamp: segment.start,
                         });
+                        segmentIndices.push(segmentIndex);
                     }
                     if (segment?.type === "move" && Array.isArray(segment.points)) {
-                        points.push(...segment.points);
+                        segment.points.forEach((point) => {
+                            points.push(point);
+                            segmentIndices.push(segmentIndex);
+                        });
                     }
                 });
 
@@ -74,6 +108,7 @@ export class TimelineLeafletMap {
                     entityIndex: index,
                     isActive: index === activeEntityIndex,
                     points,
+                    segmentIndices,
                     color: getTrackColor(index, colors),
                     opacity: index === activeEntityIndex ? 1 : 0.8,
                     weight: 4,
@@ -110,6 +145,7 @@ export class TimelineLeafletMap {
                     weight: 7,
                     opacity: 1,
                     borderWeight: 10,
+                    animated: this._animateHighlightedPath,
                 },
             ];
             this._isTravelHighlightActive = true;
@@ -157,40 +193,49 @@ export class TimelineLeafletMap {
     }
 
     _drawMapMarkers(segments) {
-        const stayMarkers = Array.isArray(segments) ? segments.filter((segment) => segment?.type === "stay") : [];
+        const segmentList = Array.isArray(segments) ? segments : [];
 
-        stayMarkers.forEach((stay) => {
-            const iconName = stay.zoneIcon || "mdi:map-marker";
-            const icon = createMarkerIcon({
-                iconName: iconName,
-                markerSize: 18,
-                iconSize: 14,
-                backgroundColor: this._activeTrackColor,
-                borderColor: `color-mix(in srgb, black 30%, ${this._activeTrackColor})`,
-                iconPadding: "2px",
-                leafletIconSize: [22, 22],
-            });
+        const pushStayMarker = (stay, index, iconOptions, zIndexOffset) => {
+            const icon = createMarkerIcon({iconName: stay.zoneIcon || "mdi:map-marker", ...iconOptions});
+            const marker = this._Leaflet.marker(stay.center, {icon, zIndexOffset});
+            // Build the popup lazily; Leaflet calls this only when the popup actually opens.
+            marker.bindPopup(() =>
+                buildStayPopupHtml(stay, this._locale, getStayEdgeOptions(stay, index, segmentList)),
+            );
+            marker.on("click", () => this._onSegmentClick?.(index));
+            this._mapLayers.push(marker);
+        };
 
-            this._mapLayers.push(this._Leaflet.marker(stay.center, {icon, zIndexOffset: 100}));
+        segmentList.forEach((stay, index) => {
+            if (stay?.type !== "stay") return;
+            pushStayMarker(
+                stay,
+                index,
+                {
+                    markerSize: 18,
+                    iconSize: 14,
+                    backgroundColor: this._activeTrackColor,
+                    borderColor: `color-mix(in srgb, black 30%, ${this._activeTrackColor})`,
+                    iconPadding: "2px",
+                    leafletIconSize: [22, 22],
+                },
+                100,
+            );
         });
 
         if (!this._highlightedStay) return;
 
-        const iconName = this._highlightedStay.zoneIcon || "mdi:map-marker";
-        const icon = createMarkerIcon({
-            iconName: iconName,
-            markerSize: 22,
-            iconSize: 22,
-            backgroundColor: "var(--accent-color)",
-            borderColor: "color-mix(in srgb, black 30%, var(--accent-color))",
-            leafletIconSize: [26, 26],
-        });
-
-        this._mapLayers.push(
-            this._Leaflet.marker(this._highlightedStay.center, {
-                icon,
-                zIndexOffset: 1000,
-            }),
+        pushStayMarker(
+            this._highlightedStay,
+            segmentList.indexOf(this._highlightedStay),
+            {
+                markerSize: 22,
+                iconSize: 22,
+                backgroundColor: "var(--accent-color)",
+                borderColor: "color-mix(in srgb, black 30%, var(--accent-color))",
+                leafletIconSize: [26, 26],
+            },
+            1000,
         );
     }
 
@@ -203,7 +248,7 @@ export class TimelineLeafletMap {
             if (!Array.isArray(path.points) || path.points.length < 2) return;
             const latLngs = path.points.map((point) => point.point);
 
-            if (path.isActive || path.entityIndex === undefined) {
+            if ((path.isActive || path.entityIndex === undefined) && !path.animated) {
                 this._mapLayers.push(
                     this._Leaflet.polyline(latLngs, {
                         color: `color-mix(in srgb, black 30%, ${path.color})`,
@@ -217,10 +262,15 @@ export class TimelineLeafletMap {
                 color: path.color,
                 opacity: path.opacity ?? 1,
                 weight: path.weight,
+                className: path.animated ? "timeline-marching-ants" : "",
             });
-            line.on("click", () => {
-                if (!Number.isInteger(path.entityIndex) || !this._onTrackClick) return;
-                this._onTrackClick(path.entityIndex);
+            line.on("click", (event) => {
+                if (!Number.isInteger(path.entityIndex)) return;
+                if (!path.isActive) {
+                    this._onTrackClick?.(path.entityIndex);
+                    return;
+                }
+                this._onSegmentClick?.(findNearestSegmentIndex(path.points, path.segmentIndices, event.latlng));
             });
             this._mapLayers.push(line);
         });

--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -1,15 +1,21 @@
-import en from "./languages/en.json";
-import nl from "./languages/nl.json";
+import en from "./languages/en.json" with {type: "json"};
+import nl from "./languages/nl.json" with {type: "json"};
 
 const languages = {en, nl};
 
 export function localize(string, search = "", replace = "") {
-    let lang = localStorage.getItem("selectedLanguage")
-    if (!lang || lang === "null") {
-        const _hass = document.querySelector("home-assistant").hass
-        lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+    let lang = "en";
+    // Outside a HA frontend (unit tests, a detached card) there is no storage or host element to read.
+    try {
+        lang = localStorage.getItem("selectedLanguage");
+        if (!lang || lang === "null") {
+            const _hass = document.querySelector("home-assistant").hass;
+            lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+        }
+    } catch {
+        lang = "en";
     }
-    lang = lang.replace(/['"]+/g, "").replace("-", "_");
+    lang = String(lang).replace(/['"]+/g, "").replace("-", "_");
 
     let translated;
     try {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -1,4 +1,12 @@
-import {capitalizeFirst, escapeHtml, formatDistance, formatDuration, formatTimeRange} from "./utils.js";
+import {
+    capitalizeFirst,
+    escapeHtml,
+    formatDistance,
+    formatDuration,
+    formatTimeRange,
+    getStayEdgeOptions,
+    getStayLabel,
+} from "./utils.js";
 import {localize} from "./localize/localize.js";
 
 export function renderTimeline(segments, locale, config) {
@@ -25,8 +33,7 @@ export function renderTimeline(segments, locale, config) {
                   iconMap: config.activity_icon_map || {},
                   distanceUnit: config.distance_unit || "metric",
                   hideMoving: Boolean(config.hide_moving),
-                  hideStartTime: index === 0 && segment.type === "stay",
-                  hideEndTime: index === segments.length - 1 && segment.type === "stay",
+                  ...getStayEdgeOptions(segment, index, segments),
               }),
           )
           .join("")}
@@ -47,7 +54,7 @@ function renderSegment(segment, index, options) {
               <div class="line-dot"></div>
             </div>
             <div class="content location">
-              <div class="title">${escapeHtml(segment.zoneName || segment.placeName || localize("timeline.unknown_location"))}</div>
+              <div class="title">${getStayLabel(segment)}</div>
             </div>
             <div class="content time multiline">
               <div class="meta timerange">${formatTimeRange(segment.start, segment.end, options)}</div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -188,7 +188,11 @@ export function normalizeEntityEntries(config, hass = null) {
             }
             // Places v3 no longer exposes devicetracker_entityid; fall back to the
             // documented same-length/order mapping between both lists.
-            if (placeEntityIds.length === entries.length && placeEntityIds[index] && !attributeMatched.has(placeEntityIds[index])) {
+            if (
+                placeEntityIds.length === entries.length &&
+                placeEntityIds[index] &&
+                !attributeMatched.has(placeEntityIds[index])
+            ) {
                 entry.places_entity = placeEntityIds[index];
             }
         });
@@ -230,4 +234,83 @@ export function sleep(ms) {
 export function capitalizeFirst(text) {
     if (!text) return "";
     return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+export const TIMELINE_POSITIONS = ["top", "bottom", "left", "right"];
+export const PILLS_POSITIONS = ["above", "below"];
+export const TIMELINE_SIZE = {min: 10, max: 90, default: 30};
+
+export function validateLayoutConfig(config) {
+    if (!TIMELINE_POSITIONS.includes(config.timeline_position)) {
+        throw new Error(`timeline_position must be one of ${TIMELINE_POSITIONS.join(", ")}`);
+    }
+    if (!PILLS_POSITIONS.includes(config.pills_position)) {
+        throw new Error(`pills_position must be one of ${PILLS_POSITIONS.join(", ")}`);
+    }
+}
+
+export function clampTimelineSize(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return TIMELINE_SIZE.default;
+    return Math.min(TIMELINE_SIZE.max, Math.max(TIMELINE_SIZE.min, num));
+}
+
+// Match only <hui-panel-view> > <hui-card> > card: hui-card is the one ancestor HA leaves without a
+// resolved height, and CSS cannot reach up to fix it.
+export function isSolePanelViewCard(parentTagName, grandparentTagName) {
+    return parentTagName === "HUI-CARD" && grandparentTagName === "HUI-PANEL-VIEW";
+}
+
+export function isSameCalendarDay(a, b) {
+    const dateA = a instanceof Date ? a : new Date(a);
+    const dateB = b instanceof Date ? b : new Date(b);
+    return startOfDay(dateA).getTime() === startOfDay(dateB).getTime();
+}
+
+// One label rule for the timeline row and the map popup, so the same stay never reads two ways.
+export function getStayLabel(stay) {
+    return escapeHtml(stay?.zoneName || stay?.placeName || localize("timeline.unknown_location"));
+}
+
+// The day's first and last stay run past the day boundary, so their outer time is unknown.
+export function getStayEdgeOptions(segment, index, segments) {
+    const isStay = segment?.type === "stay";
+    return {
+        hideStartTime: isStay && index === 0,
+        hideEndTime: isStay && index === segments.length - 1,
+    };
+}
+
+export function buildStayPopupHtml(stay, locale, options = {}) {
+    const timeLabel = formatTimeRange(stay.start, stay.end, {
+        locale,
+        hideStartTime: options.hideStartTime,
+        hideEndTime: options.hideEndTime,
+    });
+    const placeLabel = getStayLabel(stay);
+    const dateLabel = isSameCalendarDay(stay.start, stay.end)
+        ? ""
+        : `<div class="timeline-popup-date">${escapeHtml(formatDate(stay.start, locale))} - ${escapeHtml(formatDate(stay.end, locale))}</div>`;
+
+    return `
+      <div class="timeline-popup">
+        <div class="timeline-popup-place">${placeLabel}</div>
+        <div class="timeline-popup-time">${escapeHtml(timeLabel)}</div>
+        ${dateLabel}
+      </div>
+    `;
+}
+
+export function findNearestSegmentIndex(points, segmentIndices, latlng) {
+    const target = {lat: latlng.lat, lon: latlng.lng};
+    let best = null;
+    let bestDistance = Infinity;
+    points.forEach((entry, i) => {
+        const distance = haversineMeters(target, toLatLon(entry));
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = segmentIndices[i];
+        }
+    });
+    return best;
 }

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -1,0 +1,40 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {clampTimelineSize, isSolePanelViewCard, validateLayoutConfig} from "../src/utils.js";
+
+test("validateLayoutConfig accepts a valid timeline_position", () => {
+    assert.doesNotThrow(() => validateLayoutConfig({timeline_position: "left", pills_position: "below"}));
+});
+
+test("validateLayoutConfig throws for an invalid timeline_position", () => {
+    assert.throws(() => validateLayoutConfig({timeline_position: "sideways"}));
+});
+
+test("clampTimelineSize clamps values into the 10-90 range", () => {
+    assert.equal(clampTimelineSize(5), 10);
+    assert.equal(clampTimelineSize(95), 90);
+    assert.equal(clampTimelineSize(30), 30);
+});
+
+test("clampTimelineSize falls back to 30 for non-numeric input", () => {
+    assert.equal(clampTimelineSize("not-a-number"), 30);
+    assert.equal(clampTimelineSize(undefined), 30);
+});
+
+test("validateLayoutConfig throws for an invalid pills_position", () => {
+    assert.throws(() => validateLayoutConfig({timeline_position: "top", pills_position: "inside"}));
+});
+
+test("validateLayoutConfig accepts a full valid layout config", () => {
+    assert.doesNotThrow(() => validateLayoutConfig({timeline_position: "right", pills_position: "above"}));
+});
+
+test("isSolePanelViewCard is true only for the exact hui-card/hui-panel-view pairing", () => {
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-PANEL-VIEW"), true);
+});
+
+test("isSolePanelViewCard is false for masonry/sections embeddings", () => {
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-MASONRY-VIEW"), false);
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-SECTION"), false);
+    assert.equal(isSolePanelViewCard(undefined, undefined), false);
+});

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -1,0 +1,68 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {buildStayPopupHtml, isSameCalendarDay} from "../src/utils.js";
+
+test("isSameCalendarDay returns true for two Date objects on the same day", () => {
+    assert.equal(isSameCalendarDay(new Date("2026-08-21T09:00:00"), new Date("2026-08-21T17:30:00")), true);
+});
+
+test("isSameCalendarDay returns false across a day boundary", () => {
+    assert.equal(isSameCalendarDay(new Date("2026-08-21T23:50:00"), new Date("2026-08-22T00:10:00")), false);
+});
+
+test("buildStayPopupHtml includes the place name and omits the date line for a same-day stay", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:00:00"), end: new Date("2026-08-21T10:00:00"), zoneName: "Home"},
+        null,
+    );
+    assert.match(html, /Home/);
+    assert.doesNotMatch(html, /timeline-popup-date/);
+});
+
+test("buildStayPopupHtml includes the date line for a stay spanning midnight", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T23:50:00"), end: new Date("2026-08-22T00:10:00"), zoneName: "Home"},
+        null,
+    );
+    assert.match(html, /timeline-popup-date/);
+});
+
+test("buildStayPopupHtml escapes HTML in an untrusted place name", () => {
+    const html = buildStayPopupHtml(
+        {
+            start: new Date("2026-08-21T09:00:00"),
+            end: new Date("2026-08-21T10:00:00"),
+            zoneName: "<img src=x onerror=alert(1)>",
+        },
+        null,
+    );
+    assert.doesNotMatch(html, /<img/);
+    assert.match(html, /&lt;img/);
+});
+
+test("buildStayPopupHtml renders an actual start-finish time range", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:05:00"), end: new Date("2026-08-21T17:30:00"), zoneName: "Home"},
+        {language: "en", time_format: "24"},
+    );
+    assert.match(html, /timeline-popup-time">[^<]*\d[^<]*-[^<]*\d[^<]*</);
+});
+
+test("buildStayPopupHtml falls back to the same unknown-location label as the timeline row", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:00:00"), end: new Date("2026-08-21T10:00:00")},
+        null,
+    );
+    assert.match(html, /timeline-popup-place">Unknown location</);
+});
+
+test("buildStayPopupHtml hides the start time for the first stay of the day", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T00:00:00"), end: new Date("2026-08-21T09:14:00"), zoneName: "Home"},
+        {language: "en", time_format: "24"},
+        {hideStartTime: true},
+    );
+    const timeMatch = html.match(/timeline-popup-time">([^<]*)</);
+    assert.ok(timeMatch, "time div should be present");
+    assert.doesNotMatch(timeMatch[1], /-/);
+});

--- a/test/segment-lookup.test.js
+++ b/test/segment-lookup.test.js
@@ -1,0 +1,11 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {findNearestSegmentIndex} from "../src/utils.js";
+
+test("findNearestSegmentIndex resolves a click to the nearest tagged vertex", () => {
+    const points = [{point: [51.5, -0.1]}, {point: [51.5, -0.3]}, {point: [51.7, -0.3]}];
+    const segmentIndices = [0, 1, 2];
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.49, lng: -0.11}), 0);
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.51, lng: -0.29}), 1);
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.71, lng: -0.31}), 2);
+});


### PR DESCRIPTION
Hi,
Great project! I use this card to see where my family are during the day. These changes make that quicker to read and less fiddly to navigate. I added some animation when you click on the line to show the direction of travel, and I added options to customize the layout (e.g. to allow for the timeline section to be shown to the side of the map). I hope you like these changes. 

## What this changes

- Clicking a stay marker or the selected entity's route line scrolls the timeline to the matching entry and flashes it.
- Clicking a move segment's timeline row pans and zooms the map to fit that leg.
- Clicking a stay marker shows the place name and the time spent there.
- The highlighted move segment animates to show the direction it was travelled.
- The timeline can be placed top, bottom, left or right of the map, at a configurable width.
- The entity selector row can be placed above or below the map.
- The card fills a panel view when it is the only card in it.

New options: `timeline_position`, `timeline_size`, `pills_position`, `animate_highlighted_path`.

## Compatibility

The layout options all default to current behaviour. `animate_highlighted_path` defaults to on and makes the highlighted segment an animated dashed line. Set it to `false` for a solid line.

## Design

Each marker and each stretch of route carries the index of its segment. That makes "which row is this?" and "where is this row?" the same lookup. The index is the canonical segment index, so `reverse_timeline_order` and `hide_moving` work without a second mapping.

Layout is CSS, keyed on the card's own width. The card behaves the same in a panel, a masonry column or a narrow sidebar.

The two-column rules live inside a `@container` query, so a browser without container query support (pre Chrome 105 / Safari 16) skips them and renders the current stacked card.

The map keeps itself measured with a `ResizeObserver`. The previous one-shot invalidate at construction missed anything that resized the map without a window resize, such as the HA sidebar toggling or the entity selector row appearing.

## Testing

`npm test` (17 unit tests, added here) and `npm run build` pass. Verified live across panel, masonry and sections views, all four timeline positions, and a viewport sweep from 2880px down to 380px.

