### PR TITLE
1/4 Animate the highlighted move segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ When multiple entities are configured, the card renders all tracks on the map an
 | `reverse_timeline_order`    | boolean  | `false`      | Show timeline items from latest to earliest within the selected day.                                                                                                     |
 | `collapse_timeline`         | boolean  | `false`      | Start with the timeline section collapsed on first render.                                                                                                              |
 | `timeline_use_entity_color` | boolean  | `false`      | Use the active entity track color for the timeline spine/dots/text instead of always using HA `--primary-color`.                                                        |
+| `animate_highlighted_path`  | boolean  | `true`       | Animate ("marching ants") the currently-highlighted move segment to show direction of travel.                                                                           |
 | `colors`                    | string[] | `[]`         | Optional list of per-entity track colors. When set, these colors are used in order (cycled if needed) instead of HA `--primary-color`/`--color-x` variables.            |
 | **Misc**                    |          |              |                                                                                                                                                                         |
 | `update_interval`           | number   | `300`        | How often to refresh the card (in seconds).                                                                                                                             |
+
+## Map interactions
+
+- Hovering a timeline entry (desktop) highlights the matching segment on the map. A highlighted **move** segment animates ("marching ants") to show direction of travel when `animate_highlighted_path` is enabled (default).
 
 ## Reverse Geocoding
 

--- a/src/card.css
+++ b/src/card.css
@@ -382,3 +382,17 @@ ha-card {
 .leaflet-bottom {
   z-index: 1 !important;
 }
+
+.timeline-marching-ants {
+  stroke-dasharray: 14 10;
+  animation: timeline-marching-ants 1s linear infinite;
+}
+
+/* -24px is the negated sum of the dash pattern above; keep the two in step.
+   Do not rewrite this as a calc() over custom properties: an unresolved calc() is not
+   interpolatable, so the dashes jump between endpoints once per cycle instead of sliding. */
+@keyframes timeline-marching-ants {
+  to {
+    stroke-dashoffset: -24px;
+  }
+}

--- a/src/card.js
+++ b/src/card.js
@@ -28,6 +28,7 @@ const DEFAULT_CONFIG = {
     max_reasonable_speed_kmh: 300,
     map_appearance: "auto",
     map_height_px: 200,
+    animate_highlighted_path: true,
     distance_unit: "metric",
     colors: [],
     hide_current_location: false,
@@ -358,13 +359,13 @@ class TimelineCard extends HTMLElement {
             if (!this._config.hide_current_location) {
                 this._mapView._currentLocations = this._getCurrentEntityLocations();
             }
-            this._mapView.setDaySegments(
-                tracks,
-                this._activeEntityIndex,
-                (entityIndex) => this._setActiveEntityIndex(entityIndex),
-                this._config.colors,
-                this._config.hide_unselected_on_map,
-            );
+            this._mapView.setDaySegments(tracks, {
+                activeEntityIndex: this._activeEntityIndex,
+                onTrackClick: (entityIndex) => this._setActiveEntityIndex(entityIndex),
+                colors: this._config.colors,
+                hideUnselected: this._config.hide_unselected_on_map,
+                animateHighlightedPath: this._config.animate_highlighted_path,
+            });
             this._touchStart = null;
 
             this._updateMapFitButton();

--- a/src/config-flow.js
+++ b/src/config-flow.js
@@ -106,7 +106,8 @@ export function getConfigFormSchema() {
                         schema: [
                             {name: "collapse_timeline", selector: {boolean: {}}},
                             {name: "timeline_use_entity_color", selector: {boolean: {}}},
-                        ]
+                            {name: "animate_highlighted_path", selector: {boolean: {}}},
+                        ],
                     },
                     {name: "colors", selector: {text: {multiple: true}}},
                     {

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -34,6 +34,7 @@ export class TimelineLeafletMap {
         this._highlightedPath = [];
         this._highlightedStay = null;
         this._isTravelHighlightActive = false;
+        this._animateHighlightedPath = true;
 
         this.setDarkMode(false);
         requestAnimationFrame(() => this._leafletMap.invalidateSize());
@@ -53,7 +54,17 @@ export class TimelineLeafletMap {
         this._highlightedStay = null;
     }
 
-    setDaySegments(tracks = [], activeEntityIndex = 0, onTrackClick = null, colors = [], hideUnselected = false) {
+    setDaySegments(
+        tracks = [],
+        {
+            activeEntityIndex = 0,
+            onTrackClick = null,
+            colors = [],
+            hideUnselected = false,
+            animateHighlightedPath = true,
+        } = {},
+    ) {
+        this._animateHighlightedPath = Boolean(animateHighlightedPath);
         this._fullDayPaths = tracks
             .map((track, index) => {
                 const points = [];
@@ -110,6 +121,7 @@ export class TimelineLeafletMap {
                     weight: 7,
                     opacity: 1,
                     borderWeight: 10,
+                    animated: this._animateHighlightedPath,
                 },
             ];
             this._isTravelHighlightActive = true;
@@ -203,7 +215,7 @@ export class TimelineLeafletMap {
             if (!Array.isArray(path.points) || path.points.length < 2) return;
             const latLngs = path.points.map((point) => point.point);
 
-            if (path.isActive || path.entityIndex === undefined) {
+            if ((path.isActive || path.entityIndex === undefined) && !path.animated) {
                 this._mapLayers.push(
                     this._Leaflet.polyline(latLngs, {
                         color: `color-mix(in srgb, black 30%, ${path.color})`,
@@ -217,6 +229,7 @@ export class TimelineLeafletMap {
                 color: path.color,
                 opacity: path.opacity ?? 1,
                 weight: path.weight,
+                className: path.animated ? "timeline-marching-ants" : "",
             });
             line.on("click", () => {
                 if (!Number.isInteger(path.entityIndex) || !this._onTrackClick) return;


### PR DESCRIPTION
**PR 1 of 4** — replaces #96, split as you asked.

- **#97 — 1/4 Animate the highlighted move segment**  <- this PR
- **#101 — 2/4 Link the map and the timeline on click**
- **#102 — 3/4 Configurable timeline position and size**
- **#103 — 4/4 Fill the view in a panel dashboard**

Each of the four is based on `master` and contains only its own change, so they can be reviewed and merged independently and in any order.

> They do overlap in two places. #101, #102 and #103 each add the `npm test` script and the `localize()` fallback that makes the pure helpers testable outside a HA frontend, and #97 and #101 both convert `setDaySegments` to an options object. Whichever lands first wins; I will rebase the rest so you never resolve a conflict by hand.

Adds `animate_highlighted_path` (default `true`). The highlighted move segment is drawn with a dashed stroke whose offset animates, so direction of travel is visible on the map instead of being inferred from the timeline.

### Why the setDaySegments signature changed

It was already at five positional parameters and this adds a sixth, with two more coming in PR 2. It moves to an options object here so the later PRs each add a named key instead of another positional argument. Behaviour is unchanged. Happy to revert it to a sixth positional argument if you would rather keep the diff smaller.

### Note on the keyframe

`stroke-dashoffset: -24px` is the negated sum of the `14 10` dash pattern. It is deliberately a literal and not a `calc()` over custom properties: an unresolved `calc()` is not interpolatable, so the dashes jump between endpoints once per second instead of sliding. I shipped the `calc()` version first and had to fix it, hence the comment in the CSS.

### Compatibility

Default is `true`, so a highlighted move segment that used to be a solid bordered line becomes an animated dashed line. Set `animate_highlighted_path: false` for the previous appearance. That is the only user-visible change here.

### Testing

`npm run build` passes. Verified live in Home Assistant: sampling `stroke-dashoffset` every frame gives 31 distinct fractional values over 1s, so it interpolates rather than steps.
