### PR TITLE
2/4 Link the map and the timeline on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ When multiple entities are configured, the card renders all tracks on the map an
 | `reverse_timeline_order`    | boolean  | `false`      | Show timeline items from latest to earliest within the selected day.                                                                                                     |
 | `collapse_timeline`         | boolean  | `false`      | Start with the timeline section collapsed on first render.                                                                                                              |
 | `timeline_use_entity_color` | boolean  | `false`      | Use the active entity track color for the timeline spine/dots/text instead of always using HA `--primary-color`.                                                        |
+| `animate_highlighted_path`  | boolean  | `true`       | Animate ("marching ants") the currently-highlighted move segment to show direction of travel.                                                                           |
 | `colors`                    | string[] | `[]`         | Optional list of per-entity track colors. When set, these colors are used in order (cycled if needed) instead of HA `--primary-color`/`--color-x` variables.            |
 | **Misc**                    |          |              |                                                                                                                                                                         |
 | `update_interval`           | number   | `300`        | How often to refresh the card (in seconds).                                                                                                                             |
+
+## Map interactions
+
+- Hovering a timeline entry (desktop) highlights the matching segment on the map. A highlighted **move** segment animates ("marching ants") to show direction of travel when `animate_highlighted_path` is enabled (default).
 
 ## Reverse Geocoding
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ When multiple entities are configured, the card renders all tracks on the map an
 ## Map interactions
 
 - Hovering a timeline entry (desktop) highlights the matching segment on the map. A highlighted **move** segment animates ("marching ants") to show direction of travel when `animate_highlighted_path` is enabled (default).
+- Clicking a **stay** marker on the map opens a popup with the place name and the time spent there. Click it again, or click elsewhere on the map, to close it.
+- Clicking a **stay** marker or the selected entity's **route line** scrolls the timeline to the matching entry and briefly flashes it, expanding the list if collapsed. Clicking another entity's route line switches to that entity instead.
+- A popup closes whenever the map redraws, on the next hover or data refresh.
 
 ## Reverse Geocoding
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "module": "dist/timeline_card.js",
   "scripts": {
     "build": "rollup -c",
-    "dev": "rollup -c -w"
+    "dev": "rollup -c -w",
+    "test": "node --test"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.2",

--- a/src/card.css
+++ b/src/card.css
@@ -382,3 +382,17 @@ ha-card {
 .leaflet-bottom {
   z-index: 1 !important;
 }
+
+.timeline-marching-ants {
+  stroke-dasharray: 14 10;
+  animation: timeline-marching-ants 1s linear infinite;
+}
+
+/* -24px is the negated sum of the dash pattern above; keep the two in step.
+   Do not rewrite this as a calc() over custom properties: an unresolved calc() is not
+   interpolatable, so the dashes jump between endpoints once per cycle instead of sliding. */
+@keyframes timeline-marching-ants {
+  to {
+    stroke-dashoffset: -24px;
+  }
+}

--- a/src/card.css
+++ b/src/card.css
@@ -396,3 +396,39 @@ ha-card {
     stroke-dashoffset: -24px;
   }
 }
+
+/* Leaflet draws popup chrome on a white background in both themes, so these stay dark on light
+   deliberately and are not wired to the HA theme like the rest of the card. */
+.timeline-popup-place {
+  font-weight: 600;
+  margin-bottom: 2px;
+  color: #212121;
+}
+
+.timeline-popup-time {
+  color: #555555;
+}
+
+.timeline-popup-date {
+  font-size: 0.8rem;
+  color: #777777;
+}
+
+.entry.map-focus {
+  background-color: color-mix(in srgb, var(--timeline-color, var(--primary-color)) 35%, transparent);
+  border-radius: 8px;
+}
+
+/* Lets _scrollTimelineToSegment call scrollTo() without picking a behavior itself. */
+.body {
+  scroll-behavior: smooth;
+}
+
+/* MAP_FOCUS_FLASH_MS in card.js must outlast this fade. */
+.entry {
+  transition: background-color 1.2s ease-out;
+}
+
+.entry.map-focus {
+  transition: background-color 0s;
+}

--- a/src/card.js
+++ b/src/card.js
@@ -28,6 +28,7 @@ const DEFAULT_CONFIG = {
     max_reasonable_speed_kmh: 300,
     map_appearance: "auto",
     map_height_px: 200,
+    animate_highlighted_path: true,
     distance_unit: "metric",
     colors: [],
     hide_current_location: false,
@@ -358,13 +359,13 @@ class TimelineCard extends HTMLElement {
             if (!this._config.hide_current_location) {
                 this._mapView._currentLocations = this._getCurrentEntityLocations();
             }
-            this._mapView.setDaySegments(
-                tracks,
-                this._activeEntityIndex,
-                (entityIndex) => this._setActiveEntityIndex(entityIndex),
-                this._config.colors,
-                this._config.hide_unselected_on_map,
-            );
+            this._mapView.setDaySegments(tracks, {
+                activeEntityIndex: this._activeEntityIndex,
+                onTrackClick: (entityIndex) => this._setActiveEntityIndex(entityIndex),
+                colors: this._config.colors,
+                hideUnselected: this._config.hide_unselected_on_map,
+                animateHighlightedPath: this._config.animate_highlighted_path,
+            });
             this._touchStart = null;
 
             this._updateMapFitButton();

--- a/src/card.js
+++ b/src/card.js
@@ -19,6 +19,9 @@ import {renderTimeline} from "./timeline.js";
 import {getConfigFormSchema} from "./config-flow.js";
 import {localize} from "./localize/localize.js";
 
+// Must outlast the .entry background-color fade in card.css.
+const MAP_FOCUS_FLASH_MS = 1600;
+
 const DEFAULT_CONFIG = {
     entity: [],
     places_entity: [],
@@ -55,6 +58,8 @@ class TimelineCard extends HTMLElement {
         this._activeEntityIndex = 0;
         this._timelineCollapsed = false;
         this._updateIntervalId = null;
+        this._flashTimeoutId = null;
+        this._flashRow = null;
         this._resetMapFitMode();
         this._addEventListeners();
     }
@@ -116,6 +121,11 @@ class TimelineCard extends HTMLElement {
             clearInterval(this._updateIntervalId);
             this._updateIntervalId = null;
         }
+        if (this._flashTimeoutId) {
+            clearTimeout(this._flashTimeoutId);
+            this._flashTimeoutId = null;
+        }
+        this._flashRow = null;
     }
 
     _checkConfig() {
@@ -357,14 +367,16 @@ class TimelineCard extends HTMLElement {
         try {
             const tracks = Array.isArray(dayData.tracks) ? dayData.tracks : [];
             if (!this._config.hide_current_location) {
-                this._mapView._currentLocations = this._getCurrentEntityLocations();
+                this._mapView.setCurrentLocations(this._getCurrentEntityLocations());
             }
+            this._mapView.setLocale(this._hass?.locale);
             this._mapView.setDaySegments(tracks, {
                 activeEntityIndex: this._activeEntityIndex,
                 onTrackClick: (entityIndex) => this._setActiveEntityIndex(entityIndex),
                 colors: this._config.colors,
                 hideUnselected: this._config.hide_unselected_on_map,
                 animateHighlightedPath: this._config.animate_highlighted_path,
+                onSegmentClick: (segmentIndex) => this._scrollTimelineToSegment(segmentIndex),
             });
             this._touchStart = null;
 
@@ -677,6 +689,39 @@ class TimelineCard extends HTMLElement {
             if (segmentPoints.length < 2) return;
             this._mapView?.fitMap(segmentPoints.map(toLatLon));
         }
+    }
+
+    _scrollTimelineToSegment(segmentIndex) {
+        if (!Number.isInteger(segmentIndex) || segmentIndex < 0) return;
+
+        const body = this.shadowRoot?.getElementById("timeline-body");
+        const row = body?.querySelector(`.entry[data-segment-index="${segmentIndex}"]`);
+        // No row exists when hide_moving is on and a move segment was clicked. Bail before the
+        // expand below, or that click would open the list with nothing to show.
+        if (!body || !row) return;
+
+        // Open the collapsed list: a map click is an explicit request to look at that row.
+        if (this._timelineCollapsed) {
+            this._timelineCollapsed = false;
+            this._updateCollapseButtons();
+        }
+
+        // Measure with rects: .timeline is positioned, so offsetTop escapes the scroll container.
+        const bodyRect = body.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        const delta = rowRect.top - bodyRect.top - (bodyRect.height - rowRect.height) / 2;
+        // Scroll the list itself; scrollIntoView would also scroll the page.
+        body.scrollTo({top: body.scrollTop + delta});
+
+        if (this._flashTimeoutId) clearTimeout(this._flashTimeoutId);
+        this._flashRow?.classList.remove("map-focus");
+        this._flashRow = row;
+        row.classList.add("map-focus");
+        this._flashTimeoutId = setTimeout(() => {
+            row.classList.remove("map-focus");
+            this._flashRow = null;
+            this._flashTimeoutId = null;
+        }, MAP_FOCUS_FLASH_MS);
     }
 
     _bindTimelineTouch(body) {

--- a/src/config-flow.js
+++ b/src/config-flow.js
@@ -106,7 +106,8 @@ export function getConfigFormSchema() {
                         schema: [
                             {name: "collapse_timeline", selector: {boolean: {}}},
                             {name: "timeline_use_entity_color", selector: {boolean: {}}},
-                        ]
+                            {name: "animate_highlighted_path", selector: {boolean: {}}},
+                        ],
                     },
                     {name: "colors", selector: {text: {multiple: true}}},
                     {

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -34,6 +34,7 @@ export class TimelineLeafletMap {
         this._highlightedPath = [];
         this._highlightedStay = null;
         this._isTravelHighlightActive = false;
+        this._animateHighlightedPath = true;
 
         this.setDarkMode(false);
         requestAnimationFrame(() => this._leafletMap.invalidateSize());
@@ -53,7 +54,17 @@ export class TimelineLeafletMap {
         this._highlightedStay = null;
     }
 
-    setDaySegments(tracks = [], activeEntityIndex = 0, onTrackClick = null, colors = [], hideUnselected = false) {
+    setDaySegments(
+        tracks = [],
+        {
+            activeEntityIndex = 0,
+            onTrackClick = null,
+            colors = [],
+            hideUnselected = false,
+            animateHighlightedPath = true,
+        } = {},
+    ) {
+        this._animateHighlightedPath = Boolean(animateHighlightedPath);
         this._fullDayPaths = tracks
             .map((track, index) => {
                 const points = [];
@@ -110,6 +121,7 @@ export class TimelineLeafletMap {
                     weight: 7,
                     opacity: 1,
                     borderWeight: 10,
+                    animated: this._animateHighlightedPath,
                 },
             ];
             this._isTravelHighlightActive = true;
@@ -203,7 +215,7 @@ export class TimelineLeafletMap {
             if (!Array.isArray(path.points) || path.points.length < 2) return;
             const latLngs = path.points.map((point) => point.point);
 
-            if (path.isActive || path.entityIndex === undefined) {
+            if ((path.isActive || path.entityIndex === undefined) && !path.animated) {
                 this._mapLayers.push(
                     this._Leaflet.polyline(latLngs, {
                         color: `color-mix(in srgb, black 30%, ${path.color})`,
@@ -217,6 +229,7 @@ export class TimelineLeafletMap {
                 color: path.color,
                 opacity: path.opacity ?? 1,
                 weight: path.weight,
+                className: path.animated ? "timeline-marching-ants" : "",
             });
             line.on("click", () => {
                 if (!Number.isInteger(path.entityIndex) || !this._onTrackClick) return;

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -1,5 +1,5 @@
 import Leaflet from "leaflet";
-import {getTrackColor} from "./utils.js";
+import {buildStayPopupHtml, findNearestSegmentIndex, getStayEdgeOptions, getTrackColor} from "./utils.js";
 
 const DEFAULT_ZOOM = 13;
 
@@ -35,6 +35,8 @@ export class TimelineLeafletMap {
         this._highlightedStay = null;
         this._isTravelHighlightActive = false;
         this._animateHighlightedPath = true;
+        this._locale = null;
+        this._onSegmentClick = null;
 
         this.setDarkMode(false);
         requestAnimationFrame(() => this._leafletMap.invalidateSize());
@@ -42,6 +44,14 @@ export class TimelineLeafletMap {
 
     setDarkMode(isDarkMode) {
         this._mapElement?.classList.toggle("dark", Boolean(isDarkMode));
+    }
+
+    setLocale(locale) {
+        this._locale = locale;
+    }
+
+    setCurrentLocations(locations) {
+        this._currentLocations = Array.isArray(locations) ? locations : [];
     }
 
     destroy() {
@@ -62,22 +72,31 @@ export class TimelineLeafletMap {
             colors = [],
             hideUnselected = false,
             animateHighlightedPath = true,
+            onSegmentClick = null,
         } = {},
     ) {
         this._animateHighlightedPath = Boolean(animateHighlightedPath);
+        this._onSegmentClick = typeof onSegmentClick === "function" ? onSegmentClick : null;
         this._fullDayPaths = tracks
             .map((track, index) => {
                 const points = [];
+                // Tag vertices in a parallel array: move points are cached track data shared with the
+                // card, and this runs again on every hover highlight.
+                const segmentIndices = [];
                 const segments = Array.isArray(track?.segments) ? track.segments : [];
-                segments.forEach((segment) => {
+                segments.forEach((segment, segmentIndex) => {
                     if (segment?.type === "stay" && segment.center) {
                         points.push({
                             point: [segment.center.lat, segment.center.lon],
                             timestamp: segment.start,
                         });
+                        segmentIndices.push(segmentIndex);
                     }
                     if (segment?.type === "move" && Array.isArray(segment.points)) {
-                        points.push(...segment.points);
+                        segment.points.forEach((point) => {
+                            points.push(point);
+                            segmentIndices.push(segmentIndex);
+                        });
                     }
                 });
 
@@ -85,6 +104,7 @@ export class TimelineLeafletMap {
                     entityIndex: index,
                     isActive: index === activeEntityIndex,
                     points,
+                    segmentIndices,
                     color: getTrackColor(index, colors),
                     opacity: index === activeEntityIndex ? 1 : 0.8,
                     weight: 4,
@@ -169,40 +189,49 @@ export class TimelineLeafletMap {
     }
 
     _drawMapMarkers(segments) {
-        const stayMarkers = Array.isArray(segments) ? segments.filter((segment) => segment?.type === "stay") : [];
+        const segmentList = Array.isArray(segments) ? segments : [];
 
-        stayMarkers.forEach((stay) => {
-            const iconName = stay.zoneIcon || "mdi:map-marker";
-            const icon = createMarkerIcon({
-                iconName: iconName,
-                markerSize: 18,
-                iconSize: 14,
-                backgroundColor: this._activeTrackColor,
-                borderColor: `color-mix(in srgb, black 30%, ${this._activeTrackColor})`,
-                iconPadding: "2px",
-                leafletIconSize: [22, 22],
-            });
+        const pushStayMarker = (stay, index, iconOptions, zIndexOffset) => {
+            const icon = createMarkerIcon({iconName: stay.zoneIcon || "mdi:map-marker", ...iconOptions});
+            const marker = this._Leaflet.marker(stay.center, {icon, zIndexOffset});
+            // Build the popup lazily; Leaflet calls this only when the popup actually opens.
+            marker.bindPopup(() =>
+                buildStayPopupHtml(stay, this._locale, getStayEdgeOptions(stay, index, segmentList)),
+            );
+            marker.on("click", () => this._onSegmentClick?.(index));
+            this._mapLayers.push(marker);
+        };
 
-            this._mapLayers.push(this._Leaflet.marker(stay.center, {icon, zIndexOffset: 100}));
+        segmentList.forEach((stay, index) => {
+            if (stay?.type !== "stay") return;
+            pushStayMarker(
+                stay,
+                index,
+                {
+                    markerSize: 18,
+                    iconSize: 14,
+                    backgroundColor: this._activeTrackColor,
+                    borderColor: `color-mix(in srgb, black 30%, ${this._activeTrackColor})`,
+                    iconPadding: "2px",
+                    leafletIconSize: [22, 22],
+                },
+                100,
+            );
         });
 
         if (!this._highlightedStay) return;
 
-        const iconName = this._highlightedStay.zoneIcon || "mdi:map-marker";
-        const icon = createMarkerIcon({
-            iconName: iconName,
-            markerSize: 22,
-            iconSize: 22,
-            backgroundColor: "var(--accent-color)",
-            borderColor: "color-mix(in srgb, black 30%, var(--accent-color))",
-            leafletIconSize: [26, 26],
-        });
-
-        this._mapLayers.push(
-            this._Leaflet.marker(this._highlightedStay.center, {
-                icon,
-                zIndexOffset: 1000,
-            }),
+        pushStayMarker(
+            this._highlightedStay,
+            segmentList.indexOf(this._highlightedStay),
+            {
+                markerSize: 22,
+                iconSize: 22,
+                backgroundColor: "var(--accent-color)",
+                borderColor: "color-mix(in srgb, black 30%, var(--accent-color))",
+                leafletIconSize: [26, 26],
+            },
+            1000,
         );
     }
 
@@ -231,9 +260,13 @@ export class TimelineLeafletMap {
                 weight: path.weight,
                 className: path.animated ? "timeline-marching-ants" : "",
             });
-            line.on("click", () => {
-                if (!Number.isInteger(path.entityIndex) || !this._onTrackClick) return;
-                this._onTrackClick(path.entityIndex);
+            line.on("click", (event) => {
+                if (!Number.isInteger(path.entityIndex)) return;
+                if (!path.isActive) {
+                    this._onTrackClick?.(path.entityIndex);
+                    return;
+                }
+                this._onSegmentClick?.(findNearestSegmentIndex(path.points, path.segmentIndices, event.latlng));
             });
             this._mapLayers.push(line);
         });

--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -1,15 +1,21 @@
-import en from "./languages/en.json";
-import nl from "./languages/nl.json";
+import en from "./languages/en.json" with {type: "json"};
+import nl from "./languages/nl.json" with {type: "json"};
 
 const languages = {en, nl};
 
 export function localize(string, search = "", replace = "") {
-    let lang = localStorage.getItem("selectedLanguage")
-    if (!lang || lang === "null") {
-        const _hass = document.querySelector("home-assistant").hass
-        lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+    let lang = "en";
+    // Outside a HA frontend (unit tests, a detached card) there is no storage or host element to read.
+    try {
+        lang = localStorage.getItem("selectedLanguage");
+        if (!lang || lang === "null") {
+            const _hass = document.querySelector("home-assistant").hass;
+            lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+        }
+    } catch {
+        lang = "en";
     }
-    lang = lang.replace(/['"]+/g, "").replace("-", "_");
+    lang = String(lang).replace(/['"]+/g, "").replace("-", "_");
 
     let translated;
     try {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -1,4 +1,12 @@
-import {capitalizeFirst, escapeHtml, formatDistance, formatDuration, formatTimeRange} from "./utils.js";
+import {
+    capitalizeFirst,
+    escapeHtml,
+    formatDistance,
+    formatDuration,
+    formatTimeRange,
+    getStayEdgeOptions,
+    getStayLabel,
+} from "./utils.js";
 import {localize} from "./localize/localize.js";
 
 export function renderTimeline(segments, locale, config) {
@@ -25,8 +33,7 @@ export function renderTimeline(segments, locale, config) {
                   iconMap: config.activity_icon_map || {},
                   distanceUnit: config.distance_unit || "metric",
                   hideMoving: Boolean(config.hide_moving),
-                  hideStartTime: index === 0 && segment.type === "stay",
-                  hideEndTime: index === segments.length - 1 && segment.type === "stay",
+                  ...getStayEdgeOptions(segment, index, segments),
               }),
           )
           .join("")}
@@ -47,7 +54,7 @@ function renderSegment(segment, index, options) {
               <div class="line-dot"></div>
             </div>
             <div class="content location">
-              <div class="title">${escapeHtml(segment.zoneName || segment.placeName || localize("timeline.unknown_location"))}</div>
+              <div class="title">${getStayLabel(segment)}</div>
             </div>
             <div class="content time multiline">
               <div class="meta timerange">${formatTimeRange(segment.start, segment.end, options)}</div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -231,3 +231,57 @@ export function capitalizeFirst(text) {
     if (!text) return "";
     return text.charAt(0).toUpperCase() + text.slice(1);
 }
+
+export function isSameCalendarDay(a, b) {
+    const dateA = a instanceof Date ? a : new Date(a);
+    const dateB = b instanceof Date ? b : new Date(b);
+    return startOfDay(dateA).getTime() === startOfDay(dateB).getTime();
+}
+
+// One label rule for the timeline row and the map popup, so the same stay never reads two ways.
+export function getStayLabel(stay) {
+    return escapeHtml(stay?.zoneName || stay?.placeName || localize("timeline.unknown_location"));
+}
+
+// The day's first and last stay run past the day boundary, so their outer time is unknown.
+export function getStayEdgeOptions(segment, index, segments) {
+    const isStay = segment?.type === "stay";
+    return {
+        hideStartTime: isStay && index === 0,
+        hideEndTime: isStay && index === segments.length - 1,
+    };
+}
+
+export function buildStayPopupHtml(stay, locale, options = {}) {
+    const timeLabel = formatTimeRange(stay.start, stay.end, {
+        locale,
+        hideStartTime: options.hideStartTime,
+        hideEndTime: options.hideEndTime,
+    });
+    const placeLabel = getStayLabel(stay);
+    const dateLabel = isSameCalendarDay(stay.start, stay.end)
+        ? ""
+        : `<div class="timeline-popup-date">${escapeHtml(formatDate(stay.start, locale))} - ${escapeHtml(formatDate(stay.end, locale))}</div>`;
+
+    return `
+      <div class="timeline-popup">
+        <div class="timeline-popup-place">${placeLabel}</div>
+        <div class="timeline-popup-time">${escapeHtml(timeLabel)}</div>
+        ${dateLabel}
+      </div>
+    `;
+}
+
+export function findNearestSegmentIndex(points, segmentIndices, latlng) {
+    const target = {lat: latlng.lat, lon: latlng.lng};
+    let best = null;
+    let bestDistance = Infinity;
+    points.forEach((entry, i) => {
+        const distance = haversineMeters(target, toLatLon(entry));
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = segmentIndices[i];
+        }
+    });
+    return best;
+}

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -1,0 +1,68 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {buildStayPopupHtml, isSameCalendarDay} from "../src/utils.js";
+
+test("isSameCalendarDay returns true for two Date objects on the same day", () => {
+    assert.equal(isSameCalendarDay(new Date("2026-08-21T09:00:00"), new Date("2026-08-21T17:30:00")), true);
+});
+
+test("isSameCalendarDay returns false across a day boundary", () => {
+    assert.equal(isSameCalendarDay(new Date("2026-08-21T23:50:00"), new Date("2026-08-22T00:10:00")), false);
+});
+
+test("buildStayPopupHtml includes the place name and omits the date line for a same-day stay", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:00:00"), end: new Date("2026-08-21T10:00:00"), zoneName: "Home"},
+        null,
+    );
+    assert.match(html, /Home/);
+    assert.doesNotMatch(html, /timeline-popup-date/);
+});
+
+test("buildStayPopupHtml includes the date line for a stay spanning midnight", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T23:50:00"), end: new Date("2026-08-22T00:10:00"), zoneName: "Home"},
+        null,
+    );
+    assert.match(html, /timeline-popup-date/);
+});
+
+test("buildStayPopupHtml escapes HTML in an untrusted place name", () => {
+    const html = buildStayPopupHtml(
+        {
+            start: new Date("2026-08-21T09:00:00"),
+            end: new Date("2026-08-21T10:00:00"),
+            zoneName: "<img src=x onerror=alert(1)>",
+        },
+        null,
+    );
+    assert.doesNotMatch(html, /<img/);
+    assert.match(html, /&lt;img/);
+});
+
+test("buildStayPopupHtml renders an actual start-finish time range", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:05:00"), end: new Date("2026-08-21T17:30:00"), zoneName: "Home"},
+        {language: "en", time_format: "24"},
+    );
+    assert.match(html, /timeline-popup-time">[^<]*\d[^<]*-[^<]*\d[^<]*</);
+});
+
+test("buildStayPopupHtml falls back to the same unknown-location label as the timeline row", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T09:00:00"), end: new Date("2026-08-21T10:00:00")},
+        null,
+    );
+    assert.match(html, /timeline-popup-place">Unknown location</);
+});
+
+test("buildStayPopupHtml hides the start time for the first stay of the day", () => {
+    const html = buildStayPopupHtml(
+        {start: new Date("2026-08-21T00:00:00"), end: new Date("2026-08-21T09:14:00"), zoneName: "Home"},
+        {language: "en", time_format: "24"},
+        {hideStartTime: true},
+    );
+    const timeMatch = html.match(/timeline-popup-time">([^<]*)</);
+    assert.ok(timeMatch, "time div should be present");
+    assert.doesNotMatch(timeMatch[1], /-/);
+});

--- a/test/segment-lookup.test.js
+++ b/test/segment-lookup.test.js
@@ -1,0 +1,11 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {findNearestSegmentIndex} from "../src/utils.js";
+
+test("findNearestSegmentIndex resolves a click to the nearest tagged vertex", () => {
+    const points = [{point: [51.5, -0.1]}, {point: [51.5, -0.3]}, {point: [51.7, -0.3]}];
+    const segmentIndices = [0, 1, 2];
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.49, lng: -0.11}), 0);
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.51, lng: -0.29}), 1);
+    assert.equal(findNearestSegmentIndex(points, segmentIndices, {lat: 51.71, lng: -0.31}), 2);
+});


### PR DESCRIPTION
**PR 2 of 4** — replaces #96, split as you asked.

Order: #97 -> **#98 (this)** -> #99 -> #100. Builds on #97.

> I can't push branches to this repo, so GitHub has to diff this against `master`. Until #97 merges the
> diff below therefore also contains #97's changes. The clean diff for **just this PR** is
> butako/timeline_card#5. Once #97 merges this reduces to that automatically.

Clicking a stay marker, or the selected entity's route line, scrolls the timeline to the matching entry and briefly flashes it. Stay markers also open a popup naming the place and the time spent there.

### Design

`data-segment-index` already exists on timeline rows upstream, so both directions of the interaction are one lookup on that index. Map vertices carry the same index in a parallel array, and a route-line click resolves to the nearest tagged vertex. The index is the canonical segment index, so `reverse_timeline_order` and `hide_moving` need no second mapping.

`getStayLabel` and `getStayEdgeOptions` are shared with `timeline.js` so a stay reads identically in the row and the popup. Before this, the popup and the row would have applied the unknown-location fallback differently.

### Change you may want to push back on

`localize()` now wraps its `localStorage` and `document` access in try/catch and falls back to English. Without it the module throws outside a HA frontend, which blocks unit testing any pure helper that reaches it. It is a production change made to enable tests, so flagging it explicitly. The `with {type: "json"}` import assertions in the same file are for the same reason.

### Testing

`npm test` (9 tests, added here, including popup HTML escaping) and `npm run build` pass. Verified live: clicking a stay marker and a route line both flash the correct row, and with `hide_moving: true` a move-line click is a no-op rather than flashing the wrong row.
