### PR TITLE
4/4 Fill the view in a panel dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "module": "dist/timeline_card.js",
   "scripts": {
     "build": "rollup -c",
-    "dev": "rollup -c -w"
+    "dev": "rollup -c -w",
+    "test": "node --test"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.2",

--- a/src/card.css
+++ b/src/card.css
@@ -1,9 +1,11 @@
 :host {
   display: block;
+  height: 100%;
   font-family: var(--ha-card-header-font-family, "Helvetica Neue", Arial, sans-serif);
 }
 
 ha-card {
+  height: 100%;
   overflow: hidden;
 }
 
@@ -127,6 +129,13 @@ ha-card {
   overflow: hidden;
 }
 
+/* Panel views resolve a real height on every ancestor, so drop the .body cap the grid/stack case needs. */
+.card.panel-fill .timeline-content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .timeline-section.collapsed {
   grid-template-rows: 0fr;
   opacity: 0;
@@ -172,9 +181,15 @@ ha-card {
 
 .body {
   padding: 8px 16px 16px;
-  max-height: 420px;
+  max-height: var(--timeline-max-height, 420px);
   overflow: auto;
   touch-action: pan-y;
+}
+
+.card.panel-fill .body {
+  flex: 1 1 auto;
+  min-height: 0;
+  --timeline-max-height: none;
 }
 
 .loading,

--- a/src/card.js
+++ b/src/card.js
@@ -6,6 +6,7 @@ import {
     formatDate,
     formatErrorMessage,
     getTrackColor,
+    isSolePanelViewCard,
     isToday,
     normalizeEntityEntries,
     normalizeList,
@@ -148,6 +149,24 @@ class TimelineCard extends HTMLElement {
         mapElement.style.setProperty("height", `${this._config.map_height_px}px`, "important");
     }
 
+    _isSolePanelViewCard() {
+        const parent = this.parentElement;
+        // Panel views nest us in the light DOM, but fall back to the shadow host for other embeddings.
+        const grandparent = parent?.parentElement || parent?.getRootNode()?.host;
+        return isSolePanelViewCard(parent?.tagName, grandparent?.tagName);
+    }
+
+    _applyPanelHeight() {
+        const card = this.shadowRoot?.querySelector(".card");
+        if (!card) return;
+        const isPanel = this._isSolePanelViewCard();
+        card.classList.toggle("panel-fill", isPanel);
+        if (!isPanel) return;
+        // Contain hui-card: its own parent is a flex item with min-height:auto, so an uncontained
+        // list grows the page instead of scrolling inside the card.
+        Object.assign(this.parentElement.style, {display: "block", height: "100%", contain: "size"});
+    }
+
     // Actions
     _shiftDate(direction) {
         clearReverseGeocodingQueue();
@@ -223,6 +242,8 @@ class TimelineCard extends HTMLElement {
             .querySelector("[data-action='next']")
             .toggleAttribute("disabled", this._selectedDate >= today());
         this._applyMapHeight();
+
+        this._applyPanelHeight();
 
         this._updateMapFitButton();
         this._updateCollapseButtons();

--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -1,15 +1,21 @@
-import en from "./languages/en.json";
-import nl from "./languages/nl.json";
+import en from "./languages/en.json" with {type: "json"};
+import nl from "./languages/nl.json" with {type: "json"};
 
 const languages = {en, nl};
 
 export function localize(string, search = "", replace = "") {
-    let lang = localStorage.getItem("selectedLanguage")
-    if (!lang || lang === "null") {
-        const _hass = document.querySelector("home-assistant").hass
-        lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+    let lang = "en";
+    // Outside a HA frontend (unit tests, a detached card) there is no storage or host element to read.
+    try {
+        lang = localStorage.getItem("selectedLanguage");
+        if (!lang || lang === "null") {
+            const _hass = document.querySelector("home-assistant").hass;
+            lang = _hass.selectedLanguage || _hass.language || _hass.locale?.language || "en";
+        }
+    } catch {
+        lang = "en";
     }
-    lang = lang.replace(/['"]+/g, "").replace("-", "_");
+    lang = String(lang).replace(/['"]+/g, "").replace("-", "_");
 
     let translated;
     try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -231,3 +231,9 @@ export function capitalizeFirst(text) {
     if (!text) return "";
     return text.charAt(0).toUpperCase() + text.slice(1);
 }
+
+// Match only <hui-panel-view> > <hui-card> > card: hui-card is the one ancestor HA leaves without a
+// resolved height, and CSS cannot reach up to fix it.
+export function isSolePanelViewCard(parentTagName, grandparentTagName) {
+    return parentTagName === "HUI-CARD" && grandparentTagName === "HUI-PANEL-VIEW";
+}

--- a/test/panel-view.test.js
+++ b/test/panel-view.test.js
@@ -1,0 +1,13 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {isSolePanelViewCard} from "../src/utils.js";
+
+test("isSolePanelViewCard is true only for the exact hui-card/hui-panel-view pairing", () => {
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-PANEL-VIEW"), true);
+});
+
+test("isSolePanelViewCard is false for masonry/sections embeddings", () => {
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-MASONRY-VIEW"), false);
+    assert.equal(isSolePanelViewCard("HUI-CARD", "HUI-SECTION"), false);
+    assert.equal(isSolePanelViewCard(undefined, undefined), false);
+});


### PR DESCRIPTION
**PR 4 of 4** — replaces #96, split as you asked.

- **#97 — 1/4 Animate the highlighted move segment**
- **#101 — 2/4 Link the map and the timeline on click**
- **#102 — 3/4 Configurable timeline position and size**
- **#103 — 4/4 Fill the view in a panel dashboard**  <- this PR

Each of the four is based on `master` and contains only its own change, so they can be reviewed and merged independently and in any order.

> They do overlap in two places. #101, #102 and #103 each add the `npm test` script and the `localize()` fallback that makes the pure helpers testable outside a HA frontend, and #97 and #101 both convert `setDaySegments` to an options object. Whichever lands first wins; I will rebase the rest so you never resolve a conflict by hand.

When the card is the only card in a panel view it now fills the view instead of sizing to its content.

### Why this needs JavaScript

HA gives every ancestor down to `hui-card` a resolved height but leaves `hui-card` itself unstyled, so the card's own `height: 100%` chain has nothing to resolve against. CSS cannot reach an ancestor, so the card detects that one `hui-panel-view` > `hui-card` pairing and sets the height there. If there is a supported signal for this that I have missed, I would rather use it than sniff the DOM.

Everything is scoped behind a `panel-fill` class, so grid and stack embeddings are untouched and keep the existing 420px list cap. The cap is now `var(--timeline-max-height, 420px)` so the fill case clears it by overriding one property rather than restating the rule.

### Testing

`npm test` (17) and `npm run build` pass. Verified live that a panel view fills and scrolls internally with no page overflow, while masonry and sections keep the 420px cap and leave `hui-card` untouched.
