### PR TITLE
fix: strip the Places show_time suffix from stay names

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Places v3 is a breaking change in the Places integration itself: attributes such
 - With a top-level `places_entity` list, v2 sensors are matched to trackers via their `devicetracker_entityid` attribute. That attribute no longer exists in v3, so the card falls back to matching by list position — make sure the list has the same length and order as `entity` (as was already documented).
 - History from before the v3 upgrade keeps working: for those periods the card still reads the old attributes.
 - The main v3 sensor's state is not an address but the string built from your Places *display options*. The card only uses it when it reads as a name (e.g. with the `formatted_place` option); a raw field list such as `not_home, house, 13, Beatrixstraat` is ignored, and the stay is named from the `..._place_name` sensor or from reverse geocoding (`osm_api_key`) instead.
+- Places' `show_time` option appends `(since HH:MM)` to the state, or `(since MM/DD)` once it is over a day old. Both are stripped before the name is used, so stays are not labelled with the moment the sensor happened to change.
 
 ## Notes
 

--- a/src/reverse-geocoding.js
+++ b/src/reverse-geocoding.js
@@ -13,6 +13,12 @@ const V2_ADDRESS_ATTRIBUTES = ["place_name", "street", "street_number", "city", 
 // `secondary`, `charging_station`) or a bare house number (`13`, `2a`).
 const RAW_OPTION_TOKEN = /^([a-z][a-z0-9]*(_[a-z0-9]+)*|\d+[a-z]?)$/;
 
+// Places appends this when its `show_time` option is on, swapping the time for a date
+// once the state is over a day old. Both forms are plain f-strings in the integration,
+// never translated, so matching `since` literally is safe. Same pattern as Places' own
+// `helpers.clear_since_from_state`; the `[:/]` class is what covers the date form.
+const SINCE_SUFFIX = /\s*\(since \d\d[:/]\d\d\)$/;
+
 let reverseGeocodingConfig = {
     nominatim_reverse_url: "https://nominatim.openstreetmap.org/reverse",
     request_interval_ms: 1000,
@@ -178,17 +184,26 @@ function buildIntervals(states, date, displayNameFn) {
 
 function placeDisplayName(state) {
     const attrs = state.a || {};
+    // Stripped up front so both branches are free of it: `show_time` is a Places option,
+    // not a v3 one, so a v2 sensor falling through to its state carries the suffix too.
+    const sensorState = stripSinceSuffix(state.s);
+
     if (V2_ADDRESS_ATTRIBUTES.some((key) => attrs[key])) {
         const streetAddress = [attrs.street, attrs.street_number].filter(Boolean).join(" ");
         const formatted_address = streetAddress ? [streetAddress, attrs.city].filter(Boolean).join(", ") : null;
-        return attrs.place_name || formatted_address || state.s || attrs.formatted_address || null;
+        return attrs.place_name || formatted_address || sensorState || attrs.formatted_address || null;
     }
 
     // Places v3: no address attributes left, so the state is whatever the user's display
     // options render. With `formatted_place` that is a readable name, but a plain field
     // list yields raw OSM tokens ("not_home, house, 13, Beatrixstraat"), which must not be
     // shown as an address — fall through to the place_name sensor or reverse geocoding.
-    return cleanDisplayOptionsState(state.s);
+    return cleanDisplayOptionsState(sensorState);
+}
+
+function stripSinceSuffix(value) {
+    if (typeof value !== "string") return value;
+    return value.trim().replace(SINCE_SUFFIX, "");
 }
 
 function cleanDisplayOptionsState(value) {


### PR DESCRIPTION
Follows up on the `(since …)` leftover from #94 (comment [here](https://github.com/konewka17/timeline_card/pull/94#issuecomment-5476354236)). Targets that PR's branch rather than master, since it builds on `placeDisplayName`.

## What

With Places' `show_time` option on, the sensor state carries a trailing ` (since HH:MM)` — and ` (since MM/DD)` once the state is over a day old. That suffix is not part of the place name, and the timestamp is the moment the sensor changed, so on a past day it reads as noise attached to the name.

## Two things that shaped the patch

**It is stripped before either branch, not only the v3 one.** `show_time` is a Places option, not a v3 one, so a v2 sensor that falls through to `state.s` carries the suffix too.

**Stripping first also improves the raw-token check.** A state like `home (since 08:30)` does not match `RAW_OPTION_TOKEN` while the suffix is attached — the space defeats it — so it was returned as a place name. Stripped down to `home`, it is correctly recognised as a raw display option and falls through.

## The pattern

```js
const SINCE_SUFFIX = /\s*\(since \d\d[:/]\d\d\)$/;
```

Mirrors Places' own `helpers.clear_since_from_state`, whose `[:/]` class is what covers the date form. Two deliberate differences: anchored to the end, and the leading space made optional so a state consisting only of the suffix strips to empty rather than surviving as a name.

Matching `since` literally is safe — the integration builds all three variants with plain f-strings in `update_sensor.py` and never looks up a translation. Worth knowing that the Italian config-flow label reads `(dalle xx:yy)`, which makes it look translatable; that string only describes the option in the UI.

## Verified

Ran the patched functions against 36 hours of real Places v3 history plus edge cases:

| Input | Result |
| --- | --- |
| `Thuis (since 22:30)` | `"Thuis"` |
| `not_home, house, Buitenoord, 31, Schoener (since 09:34)` | falls through |
| `Merwedestraat (since 17:27)` | `"Merwedestraat"` |
| `Thuis (since 08/30)` (date form) | `"Thuis"` |
| `home (since 08:30)` | falls through *(was: shown as a name)* |
| `Sportpark (Zuid) (since 09:00)` | `"Sportpark (Zuid)"` |
| ` (since 08:30)` (suffix only) | falls through |
| `Thuis (since 22:30)` on a v2 sensor | `"Thuis"` |

The bracket case is why I did not strip anything in brackets generally — a real place name can contain them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vXvdHKB7Cr4yYopCufsNv
