### PR TITLE
fix: don't let a detached vector layer throw in a queued animation frame

### DIFF
--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -55,6 +55,37 @@ async function loadMapStyle(url) {
     return style;
 }
 
+// @maplibre/maplibre-gl-leaflet defers its zoom and resize handling to an animation
+// frame and only reads the map inside that frame. It guards `_update` against a
+// detached layer but not `_transitionEnd` or `_zoomEnd`, so swapping to raster after a
+// lost WebGL context strands any frame that is still queued and it throws on a null
+// `_map`. These replacements mirror version 0.1.4 with the check moved inside the
+// frame, where it actually holds.
+function guardDetachedFrames(layer) {
+    const isAttached = (instance) => Boolean(instance._map && instance._glMap);
+
+    layer._zoomEnd = function () {
+        if (!isAttached(this)) return;
+        const scale = this._map.getZoomScale(this._map.getZoom());
+        Leaflet.DomUtil.setTransform(this._glMap._actualCanvas, null, scale);
+        this._zooming = false;
+        this._update();
+    };
+
+    layer._transitionEnd = function () {
+        Leaflet.Util.requestAnimFrame(function () {
+            if (!isAttached(this)) return;
+            const zoom = this._map.getZoom();
+            const center = this._map.getCenter();
+            const offset = this._map.latLngToContainerPoint(this._map.getBounds().getNorthWest());
+            this._resizeContainer();
+            Leaflet.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
+            this._glMap.once("moveend", () => this._zoomEnd());
+            this._glMap.jumpTo({center, zoom: zoom - 1});
+        }, this);
+    };
+}
+
 export class TimelineLeafletMap {
     constructor(mapElement, homeZoneCenter = null, options = {}) {
         if (!mapElement?.isConnected) {
@@ -108,6 +139,9 @@ export class TimelineLeafletMap {
             const style = await loadMapStyle(VECTOR_STYLES[this._darkMode ? "dark" : "light"]);
             if (this._destroyed) return false;
             layer = maplibreGL({style, localIdeographFontFamily: "sans-serif"});
+            // Must happen before `addTo`: `onAdd` registers `_transitionEnd` as a DOM
+            // listener and captures the function reference as it is then.
+            guardDetachedFrames(layer);
             // The adapter builds the MapLibre map in `onAdd`, so a refused context or a
             // blocked worker throws here — inside the guard, or raster is never reached.
             layer.addTo(this._leafletMap);


### PR DESCRIPTION
Point 1 from [my comment on #95](https://github.com/konewka17/timeline_card/pull/95#issuecomment-5476354419). Targets that PR's branch, since the code it fixes only exists there.

## The defect

```
TypeError: Cannot read properties of null (reading 'getZoom')
    at getZoom (@maplibre/maplibre-gl-leaflet/dist/leaflet-maplibre-gl.mjs:175:24)
```

The adapter defers its zoom and resize handling to an animation frame and only reads the Leaflet map *inside* that frame:

```js
_transitionEnd: function(e) {
    L.Util.requestAnimFrame(function() {
        var zoom = this._map.getZoom();   // throws once the layer is detached
```

It guards `_update` with `if (!this._map) return;` but not `_transitionEnd` or `_zoomEnd`. `_swapToRaster()` detaches the vector layer, so any frame still queued at that moment throws. The fallback itself completes — this is log noise, not a broken map, but it fills the Home Assistant log.

## The fix

Both methods are replaced with copies that re-check `_map` and `_glMap` inside the frame, where the check actually holds. Guarding at method entry would not help: the crash is in the deferred body, and by the time it runs the queued closure has already been created.

**The replacement has to happen before `addTo`.** `onAdd` registers `_transitionEnd` as a DOM listener on `map._proxy` and captures the function reference as it is then, so patching after `addTo` leaves that listener pointing at the original. The `resize` path picks up the replacement either way, since `getEvents` routes through `this._resize` which calls `this._transitionEnd` dynamically — but the transition path would silently keep the old one.

The bodies mirror `@maplibre/maplibre-gl-leaflet` 0.1.4, pinned in `package-lock.json`.

## Verified

Reproduced the crash and confirmed the fix against a stub layer — queue a frame, detach (`_map = null`, `_glMap = null`), let the frame fire:

| | Result |
| --- | --- |
| Unpatched library body, verbatim | `TypeError: Cannot read properties of null (reading 'getZoom')` |
| With the guard, detached | no exception, work skipped |
| With the guard, still attached | `jumpTo` and `_zoomEnd` run as before |

The first row is the exact error from the report, so the reproduction matches; the third confirms the normal path is untouched.

## Not included

Point 2 from the same comment — `destroy()` never being called — is a separate change in `card.js` and is not in this PR. Answered in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vXvdHKB7Cr4yYopCufsNv
