### PR TITLE
fix: tear the map down when the card is removed

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -57,6 +57,7 @@ class TimelineCard extends HTMLElement {
         this._activeEntityIndex = 0;
         this._timelineCollapsed = false;
         this._updateIntervalId = null;
+        this._teardownTimeout = null;
         this._resetMapFitMode();
         this._addEventListeners();
     }
@@ -114,6 +115,8 @@ class TimelineCard extends HTMLElement {
 
     // noinspection JSUnusedGlobalSymbols
     connectedCallback() {
+        clearTimeout(this._teardownTimeout);
+        this._teardownTimeout = null;
         if (!this._config) return;
         // disconnectedCallback stops the interval and setConfig is the only other place that
         // starts one, so without this a card that Home Assistant re-attaches never refreshes.
@@ -131,8 +134,19 @@ class TimelineCard extends HTMLElement {
 
         // ha-map has always done this; the card never has. Without it every replaced card
         // strands a WebGL context, and browsers cap how many may live at once.
-        this._mapView?.destroy();
-        this._mapView = null;
+        //
+        // Deferred by a task, which is the one place this departs from ha-map: Home Assistant
+        // moves cards around the DOM and a move arrives here as a disconnect immediately
+        // followed by a reconnect. Tearing down synchronously would drop and rebuild the
+        // context, and refetch the style, on every move. A view's map is not moved that way,
+        // so ha-map has no such case to handle.
+        clearTimeout(this._teardownTimeout);
+        this._teardownTimeout = setTimeout(() => {
+            this._teardownTimeout = null;
+            if (this.isConnected) return;
+            this._mapView?.destroy();
+            this._mapView = null;
+        }, 0);
     }
 
     _checkConfig() {

--- a/src/card.js
+++ b/src/card.js
@@ -113,11 +113,26 @@ class TimelineCard extends HTMLElement {
     }
 
     // noinspection JSUnusedGlobalSymbols
+    connectedCallback() {
+        if (!this._config) return;
+        // disconnectedCallback stops the interval and setConfig is the only other place that
+        // starts one, so without this a card that Home Assistant re-attaches never refreshes.
+        this._setupUpdateInterval();
+        // Only after a teardown; the first map is attached by the render pass.
+        if (this._rendered && !this._mapView) this._attachMapCard();
+    }
+
+    // noinspection JSUnusedGlobalSymbols
     disconnectedCallback() {
         if (this._updateIntervalId) {
             clearInterval(this._updateIntervalId);
             this._updateIntervalId = null;
         }
+
+        // ha-map has always done this; the card never has. Without it every replaced card
+        // strands a WebGL context, and browsers cap how many may live at once.
+        this._mapView?.destroy();
+        this._mapView = null;
     }
 
     _checkConfig() {

--- a/src/leaflet-map.js
+++ b/src/leaflet-map.js
@@ -134,6 +134,14 @@ export class TimelineLeafletMap {
             clearTimeout(this._fallbackTimeout);
         });
         document.addEventListener("visibilitychange", this._handleVisibilityChange);
+        // Tied to the map's own teardown rather than to a caller remembering, the same way
+        // the frontend does it: otherwise the timer revives a map that is already gone, and
+        // the listener keeps the whole graph — and its WebGL context — alive for the
+        // lifetime of the page.
+        this._leafletMap.on("unload", () => {
+            clearTimeout(this._fallbackTimeout);
+            document.removeEventListener("visibilitychange", this._handleVisibilityChange);
+        });
         return true;
     }
 


### PR DESCRIPTION
Point 2 from [my comment on #95](https://github.com/konewka17/timeline_card/pull/95#issuecomment-5476354419), amended to follow the frontend as you asked. Replaces #105, which you closed.

Three commits, so the last one can be dropped on its own.

## 1. Release the vector layer's listeners when the map unloads

Straight from [53816](https://github.com/home-assistant/frontend/pull/53816):

```js
this._leafletMap.on("unload", () => {
    clearTimeout(this._fallbackTimeout);
    document.removeEventListener("visibilitychange", this._handleVisibilityChange);
});
```

The fallback timer and the document-level listener were only cleared in `_swapToRaster` and `destroy`, so a map torn down by any other route left both behind. Hooking Leaflet's own `unload` ties the cleanup to the map instead of to a caller remembering.

## 2. Tear the map down when the card is removed

`destroy()` existed but nothing called it. `ha-map` has called `leafletMap.remove()` from `disconnectedCallback` all along; this gives the card the equivalent, plus a `connectedCallback` that re-attaches afterwards.

Two things fall out of it:

- **The `_destroyed` guards become live.** They could never be true while `destroy()` was never called — the checks in `_setupBaseLayer` and `_createVectorLayer` were unreachable. That is also how this covers the case 53816 handles with `if (!this.isConnected) { setup.map.remove(); return; }`: there the whole map is built asynchronously, whereas here only the style fetch is, and `_destroyed` already guards it.
- **A re-attached card stops refreshing.** `disconnectedCallback` clears the update interval and `setConfig` is the only place that ever starts one, so `connectedCallback` restarts it. That bug predates #95.

## 3. Don't rebuild the map when Home Assistant moves the card

This is the one place it departs from `ha-map`, kept separate so you can drop it.

A DOM move arrives as a disconnect immediately followed by a reconnect. Tearing down synchronously drops and rebuilds the WebGL context, and refetches the style, on every move. Deferring by a task distinguishes a move from a real removal. `ha-map` has no equivalent case — a view's map is not moved the way a dashboard card is.

## Verified

Replayed the lifecycle against both variants:

```
with commit 3 (deferred) | move    -> contexts built: 1, destroyed: 0
with commit 3 (deferred) | remove  -> destroyed: 1, mapView null: true
with commit 3 (deferred) | re-add  -> rebuilt: true, interval restarted: true
without commit 3         | move    -> contexts built: 2, destroyed: 1
without commit 3         | remove  -> destroyed: 1, mapView null: true
without commit 3         | re-add  -> rebuilt: true, interval restarted: true
no config -> no throw
```

Both variants handle a real removal and a later re-add correctly; the difference is only the churn on a move. The last line covers `connectedCallback` firing before `setConfig`, which would otherwise throw on `this._config.update_interval`.

`npm run build` passes.

## One thing left open

Closing #105 leaves the `getZoom` crash unguarded, which is fine by me — with this merged, `_swapToRaster` should become rare enough that it stops mattering in practice. But since the frontend pins the same adapter and has the same gap, I'd rather report it to `@maplibre/maplibre-gl-leaflet`, where `_update` is guarded and `_transitionEnd`/`_zoomEnd` are not. Happy to file that if you agree it belongs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vXvdHKB7Cr4yYopCufsNv
